### PR TITLE
Change capitalisation and interpunction

### DIFF
--- a/1.2/Defs/Designations/DesignationCategories.xml
+++ b/1.2/Defs/Designations/DesignationCategories.xml
@@ -3,7 +3,7 @@
   <DesignationCategoryDef>
     <defName>Hygiene</defName>
     <label>Hygiene</label>
-    <description>Things for colonists hygiene.</description>
+    <description>Things for colonists' hygiene.</description>
     <order>10</order>
     <specialDesignatorClasses>
       <li>Designator_Cancel</li>

--- a/1.2/Defs/HediffDefs/Hediffs_Hygiene.xml
+++ b/1.2/Defs/HediffDefs/Hediffs_Hygiene.xml
@@ -22,8 +22,8 @@
   
   <HediffDef>
     <defName>BadHygiene</defName>
-    <label>Bad Hygiene</label>
-    <description>Bad hygiene will increase risk of disease and impact social interaction</description>
+    <label>bad hygiene</label>
+    <description>Bad hygiene will increase risk of disease and impact social interaction.</description>
     <everCurableByItem>false</everCurableByItem>
     <defaultLabelColor>(0.8, 0.8, 0.35)</defaultLabelColor>
     <tendable>false</tendable>
@@ -59,8 +59,8 @@
 
   <HediffDef ParentName="DiseaseBase">
     <defName>Diarrhea</defName>
-    <label>Diarrhea</label>
-    <description>Diarrhea is loose, watery stools (bowel movements)</description>
+    <label>diarrhea</label>
+    <description>Diarrhea is loose, watery stools. Also known as bowel movements.</description>
     <scenarioCanAdd>true</scenarioCanAdd>
     <initialSeverity>1</initialSeverity>
     <makesSickThought>true</makesSickThought>
@@ -116,8 +116,8 @@
 
   <HediffDef ParentName="InfectionBase">
     <defName>Dysentery</defName>
-    <label>Dysentery</label>
-    <description>Dysentery is a type of gastroenteritis that results in diarrhea with blood</description>
+    <label>dysentery</label>
+    <description>Dysentery is a type of gastroenteritis that results in diarrhea with blood.</description>
     <hediffClass>HediffWithComps</hediffClass>
     <taleOnVisible>IllnessRevealed</taleOnVisible>
     <makesSickThought>true</makesSickThought>
@@ -208,7 +208,7 @@
   <HediffDef ParentName="InfectionBase">
     <defName>Cholera</defName>
     <label>cholera</label>
-    <description>Cholera is an infectious disease that causes severe watery diarrhea, which can lead to dehydration and even death if untreated</description>
+    <description>Cholera is an infectious disease that causes severe watery diarrhea, which can lead to dehydration and even death if untreated.</description>
     <taleOnVisible>IllnessRevealed</taleOnVisible>
     <makesSickThought>true</makesSickThought>
     <lethalSeverity>1</lethalSeverity>
@@ -309,7 +309,7 @@
   <HediffDef>
     <defName>DBHDehydration</defName>
     <label>dehydration</label>
-    <description>Dehydration is a condition that can occur when the loss of body fluids, mostly water, exceeds the amount that is taken in</description>
+    <description>Dehydration is a condition that can occur when the loss of body fluids, mostly water, exceeds the amount that is taken in.</description>
     <lethalSeverity>1</lethalSeverity>
     <scenarioCanAdd>true</scenarioCanAdd>
     <everCurableByItem>false</everCurableByItem>

--- a/1.2/Defs/JobDefs/Jobs_Hygiene.xml
+++ b/1.2/Defs/JobDefs/Jobs_Hygiene.xml
@@ -4,64 +4,64 @@
   <JobDef>
     <defName>TriggerFireSprinkler</defName>
     <driverClass>DubsBadHygiene.JobDriver_TriggerSprinkler</driverClass>
-    <reportString>Activating TargetA.</reportString>
+    <reportString>activating TargetA</reportString>
   </JobDef>
   
   <JobDef>
     <defName>emptySeptictank</defName>
     <driverClass>DubsBadHygiene.JobDriver_emptySepticTank</driverClass>
-    <reportString>emptying TargetA.</reportString>
+    <reportString>emptying TargetA</reportString>
   </JobDef>
   
   <JobDef>
     <defName>emptyLatrine</defName>
     <driverClass>DubsBadHygiene.JobDriver_emptyLatrine</driverClass>
-    <reportString>emptying TargetA.</reportString>
+    <reportString>emptying TargetA</reportString>
   </JobDef>
   
   <!--<JobDef>
     <defName>LoadFridge</defName>
     <driverClass>DubsBadHygiene.JobDriver_LoadFridge</driverClass>
-    <reportString>loading TargetA.</reportString>
+    <reportString>loading TargetA</reportString>
     <suspendable>false</suspendable>
   </JobDef>-->
   
   <JobDef>
     <defName>LoadWashing</defName>
     <driverClass>DubsBadHygiene.JobDriver_WashingMachineLoad</driverClass>
-    <reportString>loading TargetA.</reportString>
+    <reportString>loading TargetA</reportString>
     <suspendable>false</suspendable>
   </JobDef>
 
   <JobDef>
     <defName>UnloadWashing</defName>
     <driverClass>DubsBadHygiene.JobDriver_WashingMachineUnload</driverClass>
-    <reportString>unloading TargetA.</reportString>
+    <reportString>unloading TargetA</reportString>
   </JobDef>
   
   <JobDef>
     <defName>LoadComposter</defName>
     <driverClass>DubsBadHygiene.JobDriver_LoadComposter</driverClass>
-    <reportString>filling TargetA.</reportString>
+    <reportString>filling TargetA</reportString>
     <suspendable>false</suspendable>
   </JobDef>
 
   <JobDef>
     <defName>UnloadComposter</defName>
     <driverClass>DubsBadHygiene.JobDriver_UnloadComposter</driverClass>
-    <reportString>taking compost out of TargetA.</reportString>
+    <reportString>taking compost out of TargetA</reportString>
   </JobDef>
   
   <JobDef>
     <defName>RemoveSewage</defName>
     <driverClass>DubsBadHygiene.JobDriver_RemoveSewage</driverClass>
-    <reportString>removing sewage.</reportString>
+    <reportString>removing sewage</reportString>
   </JobDef>
 
   <JobDef>
     <defName>WatchWashingMachine</defName>
     <driverClass>DubsBadHygiene.JobDriver_WatchWashingMachine</driverClass>
-    <reportString>watching the spin cycle.</reportString>
+    <reportString>watching the spin cycle</reportString>
     <joyDuration>4000</joyDuration>
     <joyKind>Meditative</joyKind>
   </JobDef>
@@ -72,123 +72,123 @@
   <JobDef>
     <defName>DBHDrinkFromGround</defName>
     <driverClass>DubsBadHygiene.JobDriver_DrinkFromGround</driverClass>
-    <reportString>Drinking water.</reportString>
+    <reportString>drinking water</reportString>
   </JobDef>
 
   <JobDef>
     <defName>DBHDrinkFromBasin</defName>
     <driverClass>DubsBadHygiene.JobDriver_DrinkFromBasin</driverClass>
-    <reportString>Drinking water from TargetA.</reportString>
+    <reportString>drinking water from TargetA</reportString>
   </JobDef>
 
   <JobDef>
     <defName>DBHPackWaterBottle</defName>
     <driverClass>DubsBadHygiene.JobDriver_PackWaterBottle</driverClass>
-    <reportString>Filling water bottle from TargetA.</reportString>
+    <reportString>filling water bottle from TargetA</reportString>
   </JobDef>
 
   <JobDef>
     <defName>DBHStockpileWaterBottles</defName>
     <driverClass>DubsBadHygiene.JobDriver_StockpileWaterBottles</driverClass>
-    <reportString>Stockpiling water from TargetA.</reportString>
+    <reportString>stockpiling water from TargetA</reportString>
   </JobDef>
 
   <JobDef>
     <defName>UseToilet</defName>
     <driverClass>DubsBadHygiene.JobDriver_UseToilet</driverClass>
-    <reportString>using the TargetA.</reportString>
+    <reportString>using the TargetA</reportString>
   </JobDef>
 
   <JobDef>
     <defName>haveWildPoo</defName>
     <driverClass>DubsBadHygiene.JobDriver_poopOutside</driverClass>
-    <reportString>defecating in the open.</reportString>
+    <reportString>defecating in the open</reportString>
   </JobDef>
 
   <JobDef>
     <defName>useWashBucket</defName>
     <driverClass>DubsBadHygiene.JobDriver_useWashBucket</driverClass>
-    <reportString>washing with TargetA.</reportString>
+    <reportString>washing with TargetA</reportString>
   </JobDef>
 
   <JobDef>
     <defName>washAtCell</defName>
     <driverClass>DubsBadHygiene.JobDriver_washAtCell</driverClass>
-    <reportString>washing.</reportString>
+    <reportString>washing</reportString>
   </JobDef>
 
   <JobDef>
     <defName>takeShower</defName>
     <driverClass>DubsBadHygiene.JobDriver_takeShower</driverClass>
-    <reportString>showering with TargetA.</reportString>
+    <reportString>showering with TargetA</reportString>
   </JobDef>
 
   <JobDef>
     <defName>takeBath</defName>
     <driverClass>DubsBadHygiene.JobDriver_takeBath</driverClass>
-    <reportString>Having a bath.</reportString>
+    <reportString>having a bath</reportString>
     <joyKind>Meditative</joyKind>
   </JobDef>
   
   <JobDef>
     <defName>washHands</defName>
     <driverClass>DubsBadHygiene.JobDriver_washHands</driverClass>
-    <reportString>washing hands.</reportString>
+    <reportString>washing hands</reportString>
   </JobDef>
   
   <JobDef>
     <defName>washPatient</defName>
     <driverClass>DubsBadHygiene.JobDriver_washPatient</driverClass>
-    <reportString>washing TargetA.</reportString>
+    <reportString>washing TargetA</reportString>
   </JobDef>
   
   <JobDef>
     <defName>DBHAdministerFluids</defName>
     <driverClass>DubsBadHygiene.JobDriver_AdministerFluids</driverClass>
-    <reportString>Bringing water to TargetB.</reportString>
+    <reportString>bringing water to TargetB</reportString>
   </JobDef>
 
   <JobDef>
     <defName>RefillTub</defName>
     <driverClass>DubsBadHygiene.JobDriver_RefillTub</driverClass>
-    <reportString>Refilling wash tub.</reportString>
+    <reportString>refilling wash tub</reportString>
   </JobDef>
 
 
   <JobDef>
     <defName>RefillWater</defName>
     <driverClass>DubsBadHygiene.JobDriver_RefillWater</driverClass>
-    <reportString>Refilling water.</reportString>
+    <reportString>refilling water</reportString>
   </JobDef>
 
   <JobDef>
     <defName>cleanBedpan</defName>
     <driverClass>DubsBadHygiene.JobDriver_cleanBedpan</driverClass>
-    <reportString>cleaning up bedpan.</reportString>
+    <reportString>cleaning up bed pan</reportString>
   </JobDef>
   
   <JobDef>
     <defName>clearBlockage</defName>
     <driverClass>DubsBadHygiene.JobDriver_FixBlockage</driverClass>
-    <reportString>unclogging the blocked TargetA.</reportString>
+    <reportString>unclogging the blocked TargetA</reportString>
   </JobDef>
 
   <JobDef>
     <defName>TipOverSewage</defName>
     <driverClass>DubsBadHygiene.JobDriver_TipOverSewage</driverClass>
-    <reportString>tipping TargetA.</reportString>
+    <reportString>tipping TargetA</reportString>
   </JobDef>
 
   <JobDef>
     <defName>DrainWaterTankJob</defName>
     <driverClass>DubsBadHygiene.JobDriver_DrainWater</driverClass>
-    <reportString>draining TargetA.</reportString>
+    <reportString>draining TargetA</reportString>
   </JobDef>
 
   <JobDef>
     <defName>PlaceFertilizer</defName>
     <driverClass>DubsBadHygiene.JobDriver_PlaceFertilizer</driverClass>
-    <reportString>Fertilizing soil.</reportString>
+    <reportString>fertilizing soil</reportString>
   </JobDef>
 
 </Defs>

--- a/1.2/Defs/Joy/JoyGivers.xml
+++ b/1.2/Defs/Joy/JoyGivers.xml
@@ -9,7 +9,7 @@
   <JobDef>
     <defName>DBHGoSwimming</defName>
     <driverClass>DubsBadHygiene.JobDriver_GoSwimming</driverClass>
-    <reportString>Swimming.</reportString>
+    <reportString>swimming</reportString>
     <joyDuration>4000</joyDuration>
     <joyMaxParticipants>10</joyMaxParticipants>
     <joyKind>Hydrotherapy</joyKind>
@@ -19,7 +19,7 @@
   <JobDef>
     <defName>UseHotTub</defName>
     <driverClass>DubsBadHygiene.JobDriver_UseHotTub</driverClass>
-    <reportString>relaxing.</reportString>
+    <reportString>relaxing</reportString>
     <joyDuration>4000</joyDuration>
     <joyMaxParticipants>2</joyMaxParticipants>
     <joyKind>Hydrotherapy</joyKind>

--- a/1.2/Defs/ModOptions/ModOptions.xml
+++ b/1.2/Defs/ModOptions/ModOptions.xml
@@ -7,10 +7,10 @@
   
   <DubsBadHygiene.DubsModOptions>
     <defName>PipeVisibility</defName>
-    <label>Pipe Visibility</label>
+    <label>Pipe visibility</label>
     <AutoList>false</AutoList>
     <defaultSetting>1</defaultSetting>
-    <tip>How should pipes be rendered</tip>
+    <tip>How pipes should be rendered</tip>
     <options>
       <li>
         <label>Hidden</label>
@@ -28,7 +28,7 @@
     <defName>HygieneRateD</defName>
     <label>Hygiene need rate</label>
     <defaultSetting>10</defaultSetting>
-    <tip>How fast the hygiene need falls</tip>
+    <tip>How fast hygiene need decreases</tip>
     <options>
       <li>
         <label>Cheat</label>
@@ -117,7 +117,7 @@
     <defName>BladderRateD</defName>
     <label>Bladder need rate</label>
     <defaultSetting>10</defaultSetting>
-    <tip>How fast the bladder need falls</tip>
+    <tip>How fast bladder need decreases</tip>
     <options>
       <li>
         <label>Cheat</label>
@@ -244,7 +244,7 @@
     <label>Thirst need rate</label>
     <Exper>true</Exper>
     <defaultSetting>10</defaultSetting>
-    <tip>How fast the thirst need falls</tip>
+    <tip>How fast thirst need decreases</tip>
     <options>
       <li>
         <label>Cheat</label>
@@ -333,7 +333,7 @@
     <defName>ContaminationChance</defName>
     <label>Contamination chance</label>
     <defaultSetting>4</defaultSetting>
-    <tip>Multiply the chance for a colonist getting contaminated from untreated water</tip>
+    <tip>Chance for a colonist to get contaminated from untreated water</tip>
     <options>
       <li>
         <label>Cheat</label>
@@ -378,7 +378,7 @@
     <defName>WaterPumpCapacity</defName>
     <label>Water pump capacity</label>
     <defaultSetting>3</defaultSetting>
-    <tip>Multiply the capacity of water pumps</tip>
+    <tip>Capacity of water pumps</tip>
     <options>
       <li>
         <label>Cheat</label>
@@ -413,9 +413,9 @@
 
   <DubsBadHygiene.DubsModOptions>
     <defName>WaterHeatingRate</defName>
-    <label>Hot Water Usage</label>
+    <label>Hot water usage</label>
     <defaultSetting>3</defaultSetting>
-    <tip>Multiply how much hot water is used while washing</tip>
+    <tip>How much hot water is used while washing</tip>
     <options>
       <li>
         <label>Cheat</label>
@@ -452,7 +452,7 @@
     <defName>SewageGridCapacity</defName>
     <label>Sewage limit per cell</label>
     <defaultSetting>3</defaultSetting>
-    <tip>Set the limit for how much sewage can fit into a cell on the surface</tip>
+    <tip>How much sewage can fit into a cell on the surface</tip>
     <options>
       <li>
         <label>Cheat</label>
@@ -542,7 +542,7 @@
     <defName>SewageProcRate</defName>
     <label>Sewage treatment rate</label>
     <defaultSetting>4</defaultSetting>
-    <tip>Multiply how fast sewage is treated in septic tanks and sewage treatment</tip>
+    <tip>How fast sewage is treated in septic tanks and sewage treatment</tip>
     <options>
       <li>
         <label>Cheat</label>
@@ -587,7 +587,7 @@
     <defName>IrrigationGridStrength</defName>
     <label>Irrigation strength</label>
     <defaultSetting>4</defaultSetting>
-    <tip>Multiply the effect of irrigation on fertility</tip>
+    <tip>How much effect of irrigation has on fertility</tip>
     <options>
       <li>
         <label>Cheat</label>
@@ -632,7 +632,7 @@
     <defName>FertilizerGridStrength</defName>
     <label>Fertilizer strength</label>
     <defaultSetting>4</defaultSetting>
-    <tip>Multiply the effect of fertilizer on fertility</tip>
+    <tip>How much effect fertilizer has on fertility</tip>
     <options>
       <li>
         <label>Cheat</label>
@@ -675,9 +675,9 @@
 
   <DubsBadHygiene.DubsModOptions>
     <defName>TerrainFertilityFactor</defName>
-    <label>Base Terrain Fertility</label>
+    <label>Base terrain fertility</label>
     <defaultSetting>5</defaultSetting>
-    <tip>Set the base value of terrain fertility</tip>
+    <tip>Base value of terrain fertility</tip>
     <options>
       <li>
         <label>Cheat</label>
@@ -728,9 +728,9 @@
 
   <DubsBadHygiene.DubsModOptions>
     <defName>FertilizerLifespan</defName>
-    <label>Fertilizer Lifespan</label>
+    <label>Fertilizer lifespan</label>
     <defaultSetting>5</defaultSetting>
-    <tip>How long until fertilized terrain expires</tip>
+    <tip>How long terrain remains fertilized after applying fertilizer</tip>
     <options>
       <li>
         <label>cheat</label>

--- a/1.2/Defs/NeedDefs/Needs_Misc.xml
+++ b/1.2/Defs/NeedDefs/Needs_Misc.xml
@@ -5,7 +5,7 @@
     <defName>Bladder</defName>
     <needClass>DubsBadHygiene.Need_Bladder</needClass>
     <label>bladder</label>
-    <description>To prevent the risk of disease it is important to maintain a good level of sanitation by removing or treating waste, and preventing sewage from contaminating you water supply.</description>
+    <description>To prevent the risk of disease it is important to maintain a good level of sanitation by removing or treating waste, and preventing sewage from contaminating your water supply.</description>
     <onlyIfCausedByHediff>true</onlyIfCausedByHediff>
     <baseLevel>0.8</baseLevel>
     <listPriority>401</listPriority>
@@ -53,8 +53,8 @@
   <NeedDef Class="DubsBadHygiene.Needy">
     <defName>DBHThirst</defName>
     <needClass>DubsBadHygiene.Need_Thirst</needClass>
-    <label>Thirst</label>
-    <description>Water is required for many of life’s physiological processes. If this reaches zero then the creature will slowly die of dehydration</description>
+    <label>thirst</label>
+    <description>Water is required for many of life’s physiological processes. If this reaches zero then the creature will slowly die of dehydration.</description>
     <onlyIfCausedByHediff>true</onlyIfCausedByHediff>
     <minIntelligence>Humanlike</minIntelligence>
     <baseLevel>0.8</baseLevel>

--- a/1.2/Defs/RecipeDefs/Recipes_Production.xml
+++ b/1.2/Defs/RecipeDefs/Recipes_Production.xml
@@ -3,9 +3,9 @@
 	
 	<RecipeDef>
 		<defName>Make_ChemfuelFromFecalSludge</defName>
-		<label>make chemfuel from Fecal Sludge</label>
-		<description>Make a batch of chemfuel from Fecal Sludge.</description>
-		<jobString>Refining chemfuel from Fecal Sludge.</jobString>
+		<label>make chemfuel from fecal sludge</label>
+		<description>Make a batch of chemfuel from fecal sludge.</description>
+		<jobString>Refining chemfuel from fecal sludge</jobString>
 		<effectWorking>Cremate</effectWorking>
 		<soundWorking>Recipe_Cremate</soundWorking>
 		<workAmount>3000</workAmount>

--- a/1.2/Defs/ResearchProjectDefs/ResearchProjects_Hygiene.xml
+++ b/1.2/Defs/ResearchProjectDefs/ResearchProjects_Hygiene.xml
@@ -10,9 +10,9 @@
 
   <ResearchProjectDef>
     <defName>SewageSludgeComposting</defName>
-    <label>Sewage Sludge Composting</label>
+    <label>sewage sludge composting</label>
     <tab>DubsBadHygiene</tab>
-    <description>When properly treated and processed, sewage sludge becomes biosolids that offer a small boost to terrain fertility, useful for harsh environments with limited space to grow. Biosolids also produce a large boost to the fertility of sand which can make it fertile when combined with irrigation.</description>
+    <description>When properly treated and processed, sewage sludge becomes biosolids that offer a small boost to terrain fertility. Useful for harsh environments with limited space to grow. Biosolids also produce a large boost to the fertility of sand which can make it fertile when combined with irrigation.</description>
     <baseCost>800</baseCost>
     <techLevel>Medieval</techLevel>
     <researchViewX>0</researchViewX>
@@ -21,7 +21,7 @@
 
   <ResearchProjectDef>
     <defName>MultiSplitAirCon</defName>
-    <label>Multi-Split Air Conditioning</label>
+    <label>multi-split air conditioning</label>
     <tab>DubsBadHygiene</tab>
     <description>Build multi-split air conditioning systems with outdoor units piped to indoor units and freezers.</description>
     <baseCost>700</baseCost>
@@ -38,7 +38,7 @@
     <defName>Plumbing</defName>
     <label>plumbing</label>
     <tab>DubsBadHygiene</tab>
-    <description>Use pipes, plumbing fixtures, storage tanks, windwells and other apparatuses to deliver and drain water and sewage.</description>
+    <description>Use pipes, plumbing fixtures, storage tanks, wind pumps and other apparatuses to deliver and drain water and sewage.</description>
     <baseCost>400</baseCost>
     <techLevel>Medieval</techLevel>
     <tags>
@@ -53,9 +53,9 @@
 
   <ResearchProjectDef>
     <defName>LogBoilers</defName>
-    <label>Heating</label>
+    <label>heating</label>
     <tab>DubsBadHygiene</tab>
-    <description>Build log boilers which can be used to heat rooms and placed adjacent to baths to heat bathwater.</description>
+    <description>Build log boilers which can be used to heat rooms and can be placed adjacent to baths to heat bathwater.</description>
     <baseCost>400</baseCost>
     <techLevel>Medieval</techLevel>
     <tags>
@@ -67,7 +67,7 @@
 
   <ResearchProjectDef>
     <defName>CentralHeating</defName>
-    <label>Central Heating</label>
+    <label>central heating</label>
     <tab>DubsBadHygiene</tab>
     <description>Build central heating systems with radiators, hot water tanks, boilers and thermostats.</description>
     <baseCost>400</baseCost>
@@ -89,9 +89,9 @@
 
   <ResearchProjectDef>
     <defName>ModernFixtures</defName>
-    <label>Modern Bathroom Fixtures</label>
+    <label>modern bathroom fixtures</label>
     <tab>DubsBadHygiene</tab>
-    <description>Build modern style bathroom fixtures like toilets and showers.</description>
+    <description>Build modern-style bathroom fixtures like toilets and showers.</description>
     <baseCost>600</baseCost>
     <techLevel>Industrial</techLevel>
     <tags>
@@ -106,9 +106,9 @@
 
   <ResearchProjectDef>
     <defName>ElectricPumps</defName>
-    <label>Electric Pumps</label>
+    <label>electric pumps</label>
     <tab>DubsBadHygiene</tab>
-    <description>Powered water pumps for pressurised continuous water pumping.</description>
+    <description>Powered water pumps for pressurized continuous water pumping.</description>
     <baseCost>500</baseCost>
     <techLevel>Industrial</techLevel>
     <tags>
@@ -129,9 +129,9 @@
 
   <ResearchProjectDef>
     <defName>AdvancedShowers</defName>
-    <label>Power Showers</label>
+    <label>power showers</label>
     <tab>DubsBadHygiene</tab>
-    <description>Build powered showers which halves the time spent showering and improves comfort.</description>
+    <description>Build power showers which halve the time spent showering and improve comfort.</description>
     <baseCost>800</baseCost>
     <techLevel>Industrial</techLevel>
     <prerequisites>
@@ -143,7 +143,7 @@
 
   <ResearchProjectDef>
     <defName>AdvancedToilets</defName>
-    <label>Smart Toilets</label>
+    <label>smart toilets</label>
     <tab>DubsBadHygiene</tab>
     <description>Build smart toilets which are twice as water efficient as a standard toilets and provide more comfort.</description>
     <baseCost>1500</baseCost>
@@ -157,9 +157,9 @@
 
   <ResearchProjectDef>
     <defName>HotTubs</defName>
-    <label>Hot Tubs</label>
+    <label>hot tubs</label>
     <tab>DubsBadHygiene</tab>
-    <description>Build hot tubs which can be used for hydrotherapy, relaxation and pleasure.</description>
+    <description>Build hot tubs which can be used for hydrotherapy, relaxation, and pleasure.</description>
     <baseCost>2000</baseCost>
     <techLevel>Industrial</techLevel>
     <prerequisites>
@@ -172,9 +172,9 @@
 
   <ResearchProjectDef>
     <defName>LargeWaterPumps</defName>
-    <label>Industrial Scale Pumps</label>
+    <label>industrial-scale pumps</label>
     <tab>DubsBadHygiene</tab>
-    <description>Build industrial scale water pumps and storage tanks.</description>
+    <description>Build industrial-scale water pumps and storage tanks.</description>
     <baseCost>2000</baseCost>
     <techLevel>Industrial</techLevel>
     <prerequisites>
@@ -186,7 +186,7 @@
 
   <ResearchProjectDef>
     <defName>DeepWells</defName>
-    <label>Deep Wells</label>
+    <label>deep wells</label>
     <tab>DubsBadHygiene</tab>
     <description>Drill deeper wells to access a much larger area of ground water.</description>
     <baseCost>2000</baseCost>
@@ -200,7 +200,7 @@
 
   <ResearchProjectDef>
     <defName>WashingMachines</defName>
-    <label>Washing machines</label>
+    <label>washing machines</label>
     <tab>DubsBadHygiene</tab>
     <description>Build washing machines that can wash clothes so well that you couldn't even tell someone died wearing it!.</description>
     <baseCost>1200</baseCost>
@@ -214,9 +214,9 @@
 
   <ResearchProjectDef>
     <defName>WaterFiltration</defName>
-    <label>Water Filtration</label>
+    <label>water filtration</label>
     <tab>DubsBadHygiene</tab>
-    <description>Build water filtration systems which treats the water supply eliminating the risk of disease.</description>
+    <description>Build water filtration systems which treat the water supply, eliminating the risk of disease.</description>
     <baseCost>1500</baseCost>
     <techLevel>Industrial</techLevel>
     <prerequisites>
@@ -231,7 +231,7 @@
 
   <ResearchProjectDef>
     <defName>SepticTanks</defName>
-    <label>Septic Tanks</label>
+    <label>septic tanks</label>
     <tab>DubsBadHygiene</tab>
     <description>Build septic tanks which accumulate sewage and provide moderate treatment of sewage.</description>
     <baseCost>500</baseCost>
@@ -245,9 +245,9 @@
 
   <ResearchProjectDef>
     <defName>SewageTreatment</defName>
-    <label>Sewage Treatment</label>
+    <label>sewage treatment</label>
     <tab>DubsBadHygiene</tab>
-    <description>Build large sewage treatment systems which accumulate large amounts of sewage and provides fast treatment of sewage.</description>
+    <description>Build large sewage treatment systems which accumulate large amounts of sewage and provide fast treatment of sewage.</description>
     <baseCost>2000</baseCost>
     <techLevel>Industrial</techLevel>
     <prerequisites>
@@ -269,7 +269,7 @@
 
   <ResearchProjectDef>
     <defName>SwimmingPools</defName>
-    <label>Swimming Pools</label>
+    <label>swimming pools</label>
     <tab>DubsBadHygiene</tab>
     <description>Build swimming pools.</description>
     <baseCost>500</baseCost>
@@ -284,7 +284,7 @@
 
   <ResearchProjectDef>
     <defName>Irrigation</defName>
-    <label>Irrigation</label>
+    <label>irrigation</label>
     <tab>DubsBadHygiene</tab>
     <description>Build sprinklers that can irrigate soil to improve fertility.</description>
     <baseCost>300</baseCost>
@@ -301,9 +301,9 @@
 
   <ResearchProjectDef>
     <defName>FireSuppression</defName>
-    <label>Fire Suppression</label>
+    <label>fire suppression</label>
     <tab>DubsBadHygiene</tab>
-    <description>Build sprinklers that when activated can suppress fires.</description>
+    <description>Build sprinklers that suppress fires with a spray of water.</description>
     <baseCost>500</baseCost>
     <techLevel>Industrial</techLevel>
     <prerequisites>

--- a/1.2/Defs/Stats/Stats_Pawns_General.xml
+++ b/1.2/Defs/Stats/Stats_Pawns_General.xml
@@ -3,7 +3,7 @@
 
   <StatDef>
     <defName>ThirstRateMultiplier</defName>
-    <label>Thirst rate multiplier</label>
+    <label>thirst rate multiplier</label>
     <description>A multiplier on how quickly a creature becomes thirsty.</description>
     <category>BasicsPawn</category>
     <defaultBaseValue>1.0</defaultBaseValue>

--- a/1.2/Defs/Storyteller/Incidents_Map_Misc.xml
+++ b/1.2/Defs/Storyteller/Incidents_Map_Misc.xml
@@ -3,14 +3,14 @@
 
   <IncidentDef>
     <defName>TowerContamination</defName>
-    <label>Tower Contamination</label>
+    <label>tower contamination</label>
     <category>Misc</category>
     <targetTags>
       <li>Map_PlayerHome</li>
     </targetTags>
     <workerClass>DubsBadHygiene.IncidentWorker_TowerContamination</workerClass>
-    <letterLabel>Contaminated Water Tower</letterLabel>
-    <letterText>A water tower has become polluted, this poses a serious risk to the health of your colonists! Drain the tower to clear the contamination, or build a water treatment system.</letterText>
+    <letterLabel>Contaminated water tower</letterLabel>
+    <letterText>A water tower has become polluted, posing a serious health risk to your colonists. Solve the cause of the pollution and then drain the tank, or build a water treatment system.</letterText>
     <letterDef>ThreatSmall</letterDef>
     <baseChance>0.3</baseChance>
     <minRefireDays>15</minRefireDays>
@@ -19,14 +19,14 @@
 
   <!--<IncidentDef>
     <defName>SewageSpill</defName>
-    <label>Sewage spill</label>
+    <label>sewage spill</label>
     <category>Misc</category>
     <targetTags>
       <li>Map_PlayerHome</li>
     </targetTags>
     <workerClass>DubsBadHygiene.IncidentWorker_SewageSpill</workerClass>
-    <letterLabel>Sewage Spill</letterLabel>
-    <letterText>A section of plumbing has broken and sewage has spilled out, sewage can be scooped up into barrels and moved.</letterText>
+    <letterLabel>Sewage spill</letterLabel>
+    <letterText>A section of plumbing has broken and sewage has spilled out. Sewage can be scooped up into barrels and moved.</letterText>
     <letterDef>ThreatSmall</letterDef>
     <baseChance>0.3</baseChance>
     <minRefireDays>15</minRefireDays>

--- a/1.2/Defs/ThingDefs_Buildings/BuildingsA_Pipes.xml
+++ b/1.2/Defs/ThingDefs_Buildings/BuildingsA_Pipes.xml
@@ -48,7 +48,7 @@
 
   <ThingDef ParentName="DubsDirtyPipeBase">
     <defName>sewagePipeStuff</defName>
-    <label>Plumbing</label>
+    <label>plumbing</label>
     <description>Plumbing for connecting plumbed things.</description>
     <uiIconPath>DBH/UI/Plumbing</uiIconPath>
     <stuffCategories>
@@ -122,8 +122,8 @@
 
   <ThingDef ParentName="DubsDirtyPipeBase">
     <defName>airPipe</defName>
-    <label>Air-Con Pipe</label>
-    <description>Pipes for connecting air conditioning units.</description>
+    <label>air-con pipe</label>
+    <description>Pipe for connecting air-conditioning units.</description>
     <graphicData>
       <texPath>DBH/Things/Building/ducting_atlas</texPath>
       <graphicClass>Graphic_Single</graphicClass>

--- a/1.2/Defs/ThingDefs_Buildings/BuildingsB_Hygiene.xml
+++ b/1.2/Defs/ThingDefs_Buildings/BuildingsB_Hygiene.xml
@@ -46,7 +46,7 @@
 
   <ThingDef ParentName="BasedHygieneMom">
     <defName>ToiletStallDoor</defName>
-    <label>Stall Door</label>
+    <label>stall door</label>
 
     <holdsRoof>false</holdsRoof>
     <fillPercent>0.15</fillPercent>
@@ -107,8 +107,8 @@
 
   <ThingDef ParentName="BasedFixture">
     <defName>PitLatrine</defName>
-    <label>Latrine</label>
-    <description>A pit latrine that collects feces in a hole in the ground. Must be emptied manually, can be plumbed.</description>
+    <label>latrine</label>
+    <description>A pit latrine that collects faeces in a hole in the ground. Must be emptied manually, or can be plumbed.</description>
     <thingClass>DubsBadHygiene.Building_Latrine</thingClass>
     <graphicData>
       <texPath>DBH/Things/Building/Latrine</texPath>
@@ -145,8 +145,8 @@
 
   <ThingDef ParentName="BasedHygieneMom">
     <defName>PrimitiveWell</defName>
-    <label>Primitive Well</label>
-    <description>Accesses ground water, water must be hauled to a water tub before it can be used for washing or drinking.</description>
+    <label>primitive well</label>
+    <description>Accesses ground water. Water must be hauled to a water tub before it can be used for washing or drinking.</description>
     <graphicData>
       <texPath>DBH/Things/Building/Water/PrimitiveWell</texPath>
       <graphicClass>Graphic_Single</graphicClass>
@@ -190,7 +190,7 @@
   <ThingDef ParentName="BasedHygieneMom">
     <defName>WashBucket</defName>
     <label>water tub</label>
-    <description>Tub of water used for personal hygiene, must be regularly refilled with fresh water. Can also be used for drinking if thirst is enabled.</description>
+    <description>Tub of water used for personal hygiene. Must be regularly refilled with fresh water. Can also be used for drinking if thirst is enabled.</description>
     <thingClass>DubsBadHygiene.Building_washbucket</thingClass>
     <graphicData>
       <texPath>DBH/Things/Building/filthyBucket</texPath>
@@ -235,8 +235,8 @@
 
   <ThingDef ParentName="BasedHygieneMom">
     <defName>LitterBox</defName>
-    <label>Litter Box</label>
-    <description>An indoor feces and urine collection box for small animals.</description>
+    <label>litter box</label>
+    <description>An indoor faeces and urine collection box for small animals.</description>
     <thingClass>DubsBadHygiene.Building_Litterbox</thingClass>
     <graphicData>
       <texPath>DBH/Things/Building/LitterBox</texPath>
@@ -282,7 +282,7 @@
 
   <ThingDef ParentName="BasedHygieneMom">
     <defName>BurnPit</defName>
-    <label>Burn Pit</label>
+    <label>burn pit</label>
     <description>Eliminates fecal sludge by burning it as fuel. Can also be used for disposing of corpses or other detritus. Colonists may become sick if they spend too long near burning waste.</description>
     <thingClass>DubsBadHygiene.Building_BurnPit</thingClass>
     <category>Building</category>
@@ -397,8 +397,8 @@
 
   <ThingDef ParentName="DubsDirtyBasinBase">
     <defName>Fountain</defName>
-    <label>Fountain</label>
-    <description>A water fountain used for drinking and washing</description>
+    <label>fountain</label>
+    <description>A water fountain used for drinking and washing.</description>
     <graphicData>
       <drawSize>(2,2)</drawSize>
       <graphicClass>Graphic_Single</graphicClass>
@@ -439,7 +439,7 @@
 
   <ThingDef ParentName="DubsDirtyBasinBase">
     <defName>KitchenSink</defName>
-    <label>Kitchen Sink</label>
+    <label>kitchen sink</label>
     <description>Everything but a kitchen sink. Increases room cleanliness.</description>
     <graphicData>
       <drawSize>(4,2)</drawSize>
@@ -476,7 +476,7 @@
 
   <!-- Toilets -->
   <ThingDef ParentName="BasedFixture" Name="DubsDirtyTerletBase" Abstract="True">
-    <description>Sanitation fixture used for the disposal of human urine and feces.</description>
+    <description>Sanitation fixture used for the disposal of human urine and faeces.</description>
     <thingClass>DubsBadHygiene.Building_toilet</thingClass>
     <graphicData>
       <texPath>DBH/Things/Building/Toilets/toilet</texPath>
@@ -511,7 +511,7 @@
 
   <ThingDef ParentName="DubsDirtyTerletBase">
     <defName>ToiletStuff</defName>
-    <label>Toilet</label>
+    <label>toilet</label>
     <stuffCategories>
       <li>Metallic</li>
       <li>Woody</li>
@@ -551,7 +551,7 @@
 
   <ThingDef ParentName="AdvTerletBase">
     <defName>ToiletAdvStuff</defName>
-    <label>Smart Toilet</label>
+    <label>smart toilet</label>
     <costList>
       <ComponentIndustrial>1</ComponentIndustrial>
     </costList>
@@ -607,7 +607,7 @@
 
   <ThingDef ParentName="DubsDirtyBathtubBase">
     <defName>BathtubStuff</defName>
-    <label>Bathtub</label>
+    <label>bathtub</label>
     <stuffCategories>
       <li>Metallic</li>
       <li>Woody</li>
@@ -653,7 +653,7 @@
 
   <ThingDef ParentName="DubsDirtyShowerBase">
     <defName>ShowerStuff</defName>
-    <label>Shower</label>
+    <label>shower</label>
     <statBases>
       <WorkToBuild>1300</WorkToBuild>
     </statBases>
@@ -670,7 +670,7 @@
 
   <ThingDef ParentName="DubsDirtyShowerBase">
     <defName>ShowerSimple</defName>
-    <label>Simple Shower</label>
+    <label>simple shower</label>
     <graphicData>
       <drawSize>(2,2)</drawSize>
       <texPath>DBH/Things/Building/Showers/showerSimple</texPath>
@@ -688,8 +688,8 @@
 
   <ThingDef ParentName="DubsDirtyShowerBase">
     <defName>ShowerAdvStuff</defName>
-    <label>Power Shower</label>
-    <description>Features a large 110mm 4 spray powered showerhead to relax those aching muscles. Heats water on demand and doubles washing speed!</description>
+    <label>power shower</label>
+    <description>Features a large 110mm 4-spray powered shower head to relax those aching muscles. Heats water on demand and doubles washing speed!</description>
     <thingClass>DubsBadHygiene.Building_PowerShower</thingClass>
     <graphicData>
       <drawSize>(2,2)</drawSize>

--- a/1.2/Defs/ThingDefs_Buildings/BuildingsC_Joy.xml
+++ b/1.2/Defs/ThingDefs_Buildings/BuildingsC_Joy.xml
@@ -4,8 +4,8 @@
 
   <!--<ThingDef ParentName="BasedHygieneMom">
     <defName>HygieneRefrigerator</defName>
-    <label>Refrigerator</label>
-    <description>Keeps food at a low temperatures and provides easy access</description>
+    <label>refrigerator</label>
+    <description>Keeps food at a low temperature while providing easy access.</description>
     <thingClass>DubsBadHygiene.Building_Fridge</thingClass>
     <graphicData>
       <texPath>DBH/Things/Building/fridge</texPath>
@@ -87,10 +87,10 @@
   </TerrainDef>
 
   <ThingDef ParentName="BasedHygieneMom" Name="DubsSwimmingPoolBase">
-    <description>Swimming pool used for hydrotherapy, relaxation or pleasure. Must be filled with water from water towers first.</description>
+    <description>Swimming pool used for hydrotherapy, relaxation, or pleasure. Must be filled with water from water towers first.</description>
     <thingClass>DubsBadHygiene.Building_FillableThing</thingClass>
     <defName>DBHSwimmingPool</defName>
-    <label>Swimming Pool</label>
+    <label>swimming pool</label>
     <stuffCategories>
       <li>Metallic</li>
       <li>Woody</li>
@@ -141,10 +141,10 @@
   </ThingDef>
   
   <ThingDef ParentName="BasedFixture" Name="DubsHotTubBase">
-    <description>Hot tub used for hydrotherapy, relaxation or pleasure. Filled with water from water towers on first use. Self heated and does not require a sewage outlet.</description>
+    <description>Hot tub used for hydrotherapy, relaxation, or pleasure. Filled with water from water towers on first use. Self-heated and does not require a sewage outlet.</description>
     <thingClass>DubsBadHygiene.Building_HotTub</thingClass>
     <defName>HotTub</defName>
-    <label>Hot Tub</label>
+    <label>hot tub</label>
     <costList>
       <Steel>20</Steel>
       <ComponentIndustrial>4</ComponentIndustrial>
@@ -201,7 +201,7 @@
 
   <ThingDef ParentName="BasedHygieneMom">
     <defName>WashingMachine</defName>
-    <label>Washing Machine</label>
+    <label>washing machine</label>
     <description>Washes clothes so well that you can't even tell someone died wearing it!</description>
     <thingClass>DubsBadHygiene.Building_WashingMachine</thingClass>
     <graphicData>

--- a/1.2/Defs/ThingDefs_Buildings/BuildingsD_WaterManagement.xml
+++ b/1.2/Defs/ThingDefs_Buildings/BuildingsD_WaterManagement.xml
@@ -37,7 +37,7 @@
 
   <ThingDef ParentName="BasedWaterWell">
     <defName>WaterWellInlet</defName>
-    <label>Water Well</label>
+    <label>water well</label>
     <description>Accesses ground water which can be pumped by water pumps. The presence of sewage or other pollution will reduce water quality and can cause contamination.</description>
     <specialDisplayRadius>7.9</specialDisplayRadius>
     <researchPrerequisites>
@@ -57,7 +57,7 @@
 
   <ThingDef ParentName="BasedWaterWell">
     <defName>DeepWaterWellInlet</defName>
-    <label>Deep Water Well</label>
+    <label>deep water well</label>
     <description>Accesses a large area of ground water which can be pumped by water pumps. Deep wells are unaffected by pollution.</description>
     <graphicData>
       <texPath>DBH/Things/Building/Water/DeepWaterWell</texPath>
@@ -112,7 +112,7 @@
 
   <ThingDef ParentName="BasedWaterTower">
     <defName>WaterButt</defName>
-    <label>Water Butt</label>
+    <label>water butt</label>
     <thingClass>DubsBadHygiene.Building_Butt</thingClass>
     <graphicData>
       <texPath>DBH/Things/Building/Water/WaterButt</texPath>
@@ -158,7 +158,7 @@
 
   <ThingDef ParentName="BasedWaterTower">
     <defName>WaterTowerS</defName>
-    <label>Water Tower</label>
+    <label>water tower</label>
     <graphicData>
       <texPath>DBH/Things/Building/Water/WaterTowerSmall</texPath>
       <graphicClass>Graphic_Single</graphicClass>
@@ -195,7 +195,7 @@
 
   <ThingDef ParentName="BasedWaterTower">
     <defName>WaterTowerL</defName>
-    <label>Huge Water Tower</label>
+    <label>huge water tower</label>
     <graphicData>
       <texPath>DBH/Things/Building/Water/WaterTower</texPath>
       <graphicClass>Graphic_Single</graphicClass>
@@ -247,8 +247,8 @@
 
   <ThingDef ParentName="BasedWaterPump">
     <defName>WindPump</defName>
-    <label>Wind Pump</label>
-    <description>Pumps water from wells to water towers. Pumping capacity: 3000 L/day</description>
+    <label>wind pump</label>
+    <description>Pumps water from wells to water towers. Pumping capacity: 3000 L/day.</description>
     <graphicData>
       <texPath>DBH/Things/Building/Water/WindPump</texPath>
       <graphicClass>Graphic_Single</graphicClass>
@@ -302,8 +302,8 @@
 
   <ThingDef ParentName="BasedWaterPump">
     <defName>ElectricPump</defName>
-    <label>Electric Pump</label>
-    <description>Pumps water from wells to water towers. Pumping capacity: 1500 L/day</description>
+    <label>electric pump</label>
+    <description>Pumps water from wells to water towers. Pumping capacity: 1500 L/day.</description>
     <graphicData>
       <texPath>DBH/Things/Building/Water/MiniPump</texPath>
       <graphicClass>Graphic_Single</graphicClass>
@@ -344,8 +344,8 @@
   
   <ThingDef ParentName="BasedWaterPump">
     <defName>PumpingStation</defName>
-    <label>Pumping Station</label>
-    <description>Pumps water from wells to water towers. Pumping capacity: 10000 L/day</description>
+    <label>pumping station</label>
+    <description>Pumps water from wells to water towers. Pumping capacity: 10000 L/day.</description>
     <graphicData>
       <texPath>DBH/Things/Building/Water/waterPumpingStation</texPath>
       <graphicClass>Graphic_Single</graphicClass>
@@ -387,8 +387,8 @@
 
   <ThingDef ParentName="BasedHygieneMom">
     <defName>SewageOutlet</defName>
-    <label>Sewage outlet</label>
-    <description>Can be placed anywhere. Sewage will pool and spread on land or disperse in water. Sewage cleans up over time; the presence of trees, water or rain will speed this up.</description>
+    <label>sewage outlet</label>
+    <description>Can be placed anywhere. Sewage will pool and spread on land or disperse in water. Sewage cleans up over time; the presence of trees, water, or rain will speed this up.</description>
     <graphicData>
       <texPath>DBH/Things/Building/Sewage/sewagePipe</texPath>
       <graphicClass>Graphic_Multi</graphicClass>
@@ -456,8 +456,8 @@
 
   <ThingDef ParentName="BasedHygieneMom">
     <defName>SewageSepticTank</defName>
-    <label>Septic Tank</label>
-    <description>Slowly cleans sewage over time. Sewage is directed to septic tanks first. If it reaches full capacity then excess sewage is sent to sewage outlets.</description>
+    <label>septic tank</label>
+    <description>Slowly cleans sewage over time. Sewage is directed to septic tanks first. If it reaches full capacity, excess sewage is sent to sewage outlets.</description>
     <graphicData>
       <texPath>DBH/Things/Building/Sewage/SepticTank</texPath>
       <graphicClass>Graphic_Single</graphicClass>
@@ -510,7 +510,7 @@
   
   <ThingDef ParentName="BasedHygieneMom">
     <defName>SewageTreatment</defName>
-    <label>Sewage Treatment</label>
+    <label>sewage treatment</label>
     <description>Slowly cleans sewage over time. If it reaches full capacity then excess sewage is sent directly to sewage outlets without treatment.</description>
     <graphicData>
       <texPath>DBH/Things/Building/Sewage/SewageTreatment</texPath>
@@ -568,8 +568,8 @@
 
   <ThingDef ParentName="BasedHygieneMom">
     <defName>WaterTreatment</defName>
-    <label>Water Treatment</label>
-    <description>Cleans 99.99% of germs! Filters existing water in storage towers, and any water used by fixtures, eliminating the risk of disease</description>
+    <label>water treatment</label>
+    <description>Cleans 99.99% of germs! Filters existing water in storage towers, and any water used by fixtures, eliminating the risk of disease.</description>
     <graphicData>
       <texPath>DBH/Things/Building/Water/waterFiltration</texPath>
       <graphicClass>Graphic_Single</graphicClass>

--- a/1.2/Defs/ThingDefs_Buildings/BuildingsE_Heating.xml
+++ b/1.2/Defs/ThingDefs_Buildings/BuildingsE_Heating.xml
@@ -17,8 +17,8 @@
 
   <ThingDef ParentName="BasedHeating">
     <defName>Thermostat</defName>
-    <label>Thermostat</label>
-    <description>Used to control electric and gas boilers. More than 1 can be placed. Connects via standard plumbing.</description>
+    <label>thermostat</label>
+    <description>Used to control electric and gas boilers. More than one can be placed. Connects via standard plumbing.</description>
     <graphicData>
       <texPath>DBH/Things/Building/Heating/thermostat</texPath>
       <graphicClass>Graphic_Multi</graphicClass>
@@ -58,7 +58,7 @@
 
   <ThingDef ParentName="BasedHeating">
     <defName>LogBoiler</defName>
-    <label>Log boiler</label>
+    <label>log boiler</label>
     <description>Produces 2000 heating units for piped radiators and hot water tanks. Heats the room and adjacent baths. Requires wood logs for fuel.</description>
     <graphicData>
       <texPath>DBH/Things/Building/Heating/Stove</texPath>
@@ -123,7 +123,7 @@
 
   <ThingDef ParentName="BasedHeating">
     <defName>GasBoiler</defName>
-    <label>Gas boiler</label>
+    <label>gas boiler</label>
     <description>Produces 2000 heating units for radiators and hot water tanks. Requires chemfuel for fuel. Can be controlled by thermostats.</description>
     <graphicData>
       <texPath>DBH/Things/Building/Heating/GasBoiler</texPath>
@@ -185,7 +185,7 @@
 
   <ThingDef ParentName="BasedHeating">
     <defName>ElectricBoiler</defName>
-    <label>Electric Boiler</label>
+    <label>electric boiler</label>
     <description>Produces a variable amount of heating units for radiators and hot water tanks. Manually controlled power setting. Can be controlled by thermostats.</description>
     <graphicData>
       <texPath>DBH/Things/Building/Heating/ElectricBoiler</texPath>
@@ -243,7 +243,7 @@
 
   <ThingDef ParentName="BasedHygieneMom">
     <defName>SolarHeater</defName>
-    <label>Solar Heater</label>
+    <label>solar heater</label>
     <description>Uses sunlight to heat hot water tanks and radiators. 0-2000 units of heating power depending on light level and ambient temperature.</description>
     <graphicData>
       <texPath>DBH/Things/Building/Heating/solarHeater</texPath>
@@ -282,7 +282,7 @@
 
   <ThingDef ParentName="BasedHeating">
     <defName>HotWaterTank</defName>
-    <label>Hot Water Tank</label>
+    <label>hot water tank</label>
     <description>Stores hot running water for showers and baths. Connect to any boiler to heat.</description>
     <graphicData>
       <texPath>DBH/Things/Building/Heating/Boiler</texPath>
@@ -373,7 +373,7 @@
 
   <ThingDef ParentName="BaseRadiator">
     <defName>RadiatorStuffed</defName>
-    <label>Radiator</label>
+    <label>radiator</label>
     <uiIconPath>DBH/UI/radiator</uiIconPath>
     <costList>
       <Steel>15</Steel>
@@ -394,7 +394,7 @@
 
   <ThingDef ParentName="BaseRadiator">
     <defName>RadiatorLarge</defName>
-    <label>Large Radiator</label>
+    <label>large radiator</label>
     <uiIconPath>DBH/UI/radiator</uiIconPath>
     <graphicData>
       <texPath>DBH/Things/Building/Heating/radiatorLarge</texPath>
@@ -404,7 +404,7 @@
         <rect>(0.05,0.05,0.95,0.95)</rect>
       </damageData>
     </graphicData>
-    <description>3 times the output of a standard radiator, useful for larger rooms. Requires 300 heating units.</description>
+    <description>Three times the output of a standard radiator. Useful for larger rooms. Requires 300 heating units.</description>
     <size>(2,1)</size>
     <costList>
       <Steel>15</Steel>
@@ -431,7 +431,7 @@
 
   <ThingDef ParentName="BasedHeating">
     <defName>CeilingFan</defName>
-    <label>Ceiling Fan 2x2</label>
+    <label>ceiling fan 2x2</label>
     <thingClass>DubsBadHygiene.Building_CeilingFan</thingClass>
     <graphicData>
       <texPath>DBH/Things/Building/Heating/CeilingFanBlades</texPath>
@@ -441,7 +441,7 @@
     <terrainAffordanceNeeded>Light</terrainAffordanceNeeded>
     <altitudeLayer>Weather</altitudeLayer>
     <clearBuildingArea>false</clearBuildingArea>
-    <description>Cools a room by circulating air. Includes a built in lamp.</description>
+    <description>Cools a room by circulating air. Includes a built-in lamp.</description>
     <passability>Standable</passability>
     <drawerType>RealtimeOnly</drawerType>
     <blockWind>false</blockWind>
@@ -492,7 +492,7 @@
 
   <ThingDef ParentName="BasedHeating">
     <defName>CeilingFanS</defName>
-    <label>Ceiling Fan 1x1</label>
+    <label>ceiling fan 1x1</label>
     <thingClass>DubsBadHygiene.Building_CeilingFan</thingClass>
     <graphicData>
       <texPath>DBH/Things/Building/Heating/CeilingFanBlades</texPath>
@@ -503,7 +503,7 @@
     <terrainAffordanceNeeded>Light</terrainAffordanceNeeded>
     <altitudeLayer>Weather</altitudeLayer>
     <clearBuildingArea>false</clearBuildingArea>
-    <description>Cools a room by circulating air. Includes a built in lamp.</description>
+    <description>Cools a room by circulating air. Includes a built-in lamp.</description>
     <passability>Standable</passability>
     <drawerType>RealtimeOnly</drawerType>
     <blockWind>false</blockWind>
@@ -558,8 +558,8 @@
   
   <ThingDef ParentName="BasedHeating">
     <defName>AirConOutdoorUnit</defName>
-    <label>Air-Con Outdoor Unit</label>
-    <description>Multi-split Air Conditioner unit. Place outdoors and pipe to indoor units or freezer units. Power mode selection with 100-1000 cooling units capacity</description>
+    <label>air-con outdoor unit</label>
+    <description>Multi-split air conditioner unit. Place outdoors and pipe to indoor units or freezer units. Power mode selection with 100-1000 cooling units capacity.</description>
     <graphicData>
       <texPath>DBH/Things/Building/Heating/Aircon</texPath>
       <graphicClass>Graphic_Single</graphicClass>
@@ -631,8 +631,8 @@
 
   <ThingDef ParentName="BaseAircon">
     <defName>AirconIndoorUnit</defName>
-    <label>Air-Con Indoor Unit</label>
-    <description>Indoor Air-con unit for rooms. Connect to outdoor air-con units. Requires 100 cooling units.</description>
+    <label>air-con indoor unit</label>
+    <description>Indoor air-con unit for rooms. Connect to outdoor air-con units. Requires 100 cooling units.</description>
     <costList>
       <Steel>25</Steel>
     </costList>
@@ -676,8 +676,8 @@
 
   <ThingDef ParentName="BaseAircon">
     <defName>FreezerUnit</defName>
-    <label>Walk-in freezer unit</label>
-    <description>Freezer unit for creating a walk in freezer. Connect to outdoor air-con units. Requires 300 cooling units.</description>
+    <label>walk-in freezer unit</label>
+    <description>Freezer unit for creating a walk-in freezer. Connect to outdoor air-con units. Requires 300 cooling units.</description>
     <costList>
       <Steel>30</Steel>
       <ComponentIndustrial>1</ComponentIndustrial>

--- a/1.2/Defs/ThingDefs_Buildings/BuildingsF_Irrigation.xml
+++ b/1.2/Defs/ThingDefs_Buildings/BuildingsF_Irrigation.xml
@@ -5,8 +5,8 @@
 
   <ThingDef ParentName="BasedHygieneMom">
     <defName>IrrigationSprinkler</defName>
-    <label>Irrigation Sprinkler</label>
-    <description>Waters the surrounding area once every morning to improve the fertility of the soil through the day. Requires large amounts of water from water towers while spraying</description>
+    <label>irrigation sprinkler</label>
+    <description>Waters the surrounding area once every morning to improve the fertility of the soil through the day. Requires large amounts of water from water towers while spraying.</description>
     <graphicData>
       <texPath>DBH/Things/Building/sprinkler</texPath>
       <graphicClass>Graphic_Single</graphicClass>
@@ -67,8 +67,8 @@
 
   <ThingDef ParentName="BasedHygieneMom">
     <defName>FireSprinkler</defName>
-    <label>Fire Sprinkler</label>
-    <description>Triggered by fire or high temperature. Douses flames with a spray of water</description>
+    <label>fire sprinkler</label>
+    <description>Triggered by fire or high temperature. Douses flames with a spray of water.</description>
     <graphicData>
       <texPath>DBH/Things/Building/firesprinkler</texPath>
       <graphicClass>Graphic_Single</graphicClass>
@@ -136,7 +136,7 @@
 
   <ThingDef ParentName="BasedHygieneMom">
     <defName>BiosolidsComposter</defName>
-    <label>Biosolids Composter</label>
+    <label>biosolids composter</label>
     <thingClass>DubsBadHygiene.Building_Composter</thingClass>
     <graphicData>
       <texPath>DBH/Things/Building/Sewage/Composter</texPath>
@@ -187,7 +187,7 @@
 
   <!--<ThingDef ParentName="BasedHygieneMom">
     <defName>BiosolidFertilizer</defName>
-    <label>Biosolid Fertilizer</label>
+    <label>biosolid fertilizer</label>
     <description>Biosolid fertilizer used for increasing the fertility of diggable terrain. Lasts just under 1 year.</description>
     <selectable>false</selectable>
     <uiIconPath>DBH/UI/fertilizer</uiIconPath>

--- a/1.2/Defs/ThingDefs_Items/Items_Resource_Stuff.xml
+++ b/1.2/Defs/ThingDefs_Items/Items_Resource_Stuff.xml
@@ -23,7 +23,7 @@
 
   <ThingDef>
     <defName>BedPan</defName>
-    <label>Bed Pan</label>
+    <label>bed pan</label>
     <description>A receptacle used by a bedridden patient for urine and faeces.</description>
     <graphicData>
       <graphicClass>Graphic_Single</graphicClass>
@@ -58,7 +58,7 @@
   <ThingDef ParentName="ResourceBasedMom">
     <defName>Biosolids</defName>
     <label>biosolids</label>
-    <description>When properly treated and processed, sewage sludge becomes biosolids that offer a small boost to terrain fertility, useful for harsh environments with limited space to grow. Biosolids also produce a large boost to the fertility of sand which can make it fertile when combined with irrigation.</description>
+    <description>When properly treated and processed, sewage sludge becomes biosolids that offer a small boost to terrain fertility. Useful for harsh environments with limited space to grow. Biosolids also produce a large boost to the fertility of sand which can make it fertile when combined with irrigation.</description>
     <graphicData>
       <texPath>DBH/Things/Resource/bagSoil</texPath>
       <graphicClass>Graphic_Single</graphicClass>
@@ -79,8 +79,8 @@
 
   <ThingDef ParentName="ResourceBasedMom">
     <defName>FecalSludge</defName>
-    <label>Fecal Sludge</label>
-    <description>A barrel filled with fecal sludge, can be dumped, burned, or composted into biosolids.</description>
+    <label>fecal sludge</label>
+    <description>A barrel filled with fecal sludge. Can be dumped, burned, or composted into biosolids.</description>
     <graphicData>
       <texPath>DBH/Things/Resource/BurnBarrel</texPath>
       <graphicClass>Graphic_Single</graphicClass>
@@ -107,7 +107,7 @@
   <!--Example of a drink for the thirst need, modExtension makes anything ingestible work as a drink, this is patched out when thirst is disabled-->
   <ThingDef ParentName="ResourceBasedMom">
     <defName>DBH_WaterBottle</defName>
-    <label>Water</label>
+    <label>water</label>
     <description>A bottle of water.</description>
     <modExtensions>
       <li Class="DubsBadHygiene.WaterExt">

--- a/1.2/Defs/ThoughtDefs/Thoughts_Memory_Hygiene.xml
+++ b/1.2/Defs/ThoughtDefs/Thoughts_Memory_Hygiene.xml
@@ -7,8 +7,8 @@
     <stackLimit>1</stackLimit>
     <stages>
       <li>
-        <label>Refreshed</label>
-        <description>Drank refreshing clean water</description>
+        <label>refreshed</label>
+        <description>Drank refreshing clean water.</description>
         <baseMoodEffect>2</baseMoodEffect>
       </li>
     </stages>
@@ -21,8 +21,8 @@
     <stackLimit>1</stackLimit>
     <stages>
       <li>
-        <label>Drank filthy water</label>
-        <description>Drank a bottle of contaminated water</description>
+        <label>drank filthy water</label>
+        <description>Drank a bottle of contaminated water.</description>
         <baseMoodEffect>-3</baseMoodEffect>
       </li>
     </stages>
@@ -35,8 +35,8 @@
     <stackLimit>3</stackLimit>
     <stages>
       <li>
-        <label>Drank urine</label>
-        <description>Drank my own urine.</description>
+        <label>drank urine</label>
+        <description>I drank my own urine.</description>
         <baseMoodEffect>-10</baseMoodEffect>
       </li>
     </stages>
@@ -64,7 +64,7 @@
     <stages>
       <li>
         <label>embarrassed</label>
-        <description>Someone walked in on me while i was using the toilet!</description>
+        <description>Someone walked in on me while I was using the toilet.</description>
         <baseMoodEffect>-3</baseMoodEffect>
       </li>
     </stages>
@@ -91,7 +91,7 @@
 		<stackLimit>1</stackLimit>
 		<stages>
 			<li>
-				<label>Hot shower</label>
+				<label>hot shower</label>
 				<description>I had a nice hot shower.</description>
 				<baseMoodEffect>3</baseMoodEffect>
 			</li>
@@ -105,7 +105,7 @@
 		<stackLimit>1</stackLimit>
 		<stages>
 			<li>
-				<label>Hot bath</label>
+				<label>hot bath</label>
 				<description>I had a nice hot bath.</description>
 				<baseMoodEffect>3</baseMoodEffect>
 			</li>
@@ -119,7 +119,7 @@
 		<stackLimit>1</stackLimit>
 		<stages>
 			<li>
-				<label>Cold bath</label>
+				<label>cold bath</label>
 				<description>I had a nice refreshing cold bath.</description>
 				<baseMoodEffect>3</baseMoodEffect>
 			</li>
@@ -133,7 +133,7 @@
 		<stackLimit>1</stackLimit>
 		<stages>
 			<li>
-				<label>Cold shower</label>
+				<label>cold shower</label>
 				<description>I had a nice refreshing cold shower.</description>
 				<baseMoodEffect>3</baseMoodEffect>
 			</li>
@@ -147,7 +147,7 @@
     <stackLimit>1</stackLimit>
     <stages>
       <li>
-        <label>Cold water</label>
+        <label>cold water</label>
         <description>There was no hot water!</description>
         <baseMoodEffect>-3</baseMoodEffect>
       </li>
@@ -161,7 +161,7 @@
 		<stackLimit>1</stackLimit>
 		<stages>
 			<li>
-				<label>Relieved myself</label>
+				<label>relieved myself</label>
 				<description>Aaaah much better.</description>
 				<baseMoodEffect>3</baseMoodEffect>
 			</li>
@@ -174,7 +174,7 @@
 		<stackLimit>1</stackLimit>
 		<stages>
 			<li>
-				<label>Open defecation</label>
+				<label>open defecation</label>
 				<description>I had to relieve myself outside in the open.</description>
 				<baseMoodEffect>-3</baseMoodEffect>
 			</li>

--- a/1.2/Defs/ThoughtDefs/Thoughts_Situation_Needs.xml
+++ b/1.2/Defs/ThoughtDefs/Thoughts_Situation_Needs.xml
@@ -6,22 +6,22 @@
     <workerClass>DubsBadHygiene.ThoughtWorker_Hygiene</workerClass>
     <stages>
       <li>
-        <label>Filthy</label> 
-        <description>I smell like i have been swimming in sewage.</description>
+        <label>filthy</label>
+        <description>I smell like I have been swimming in sewage.</description>
         <baseMoodEffect>-6</baseMoodEffect>
       </li>
       <li>
-        <label>Grimy</label>
+        <label>grimy</label>
         <description>I feel a little grimy.</description>
         <baseMoodEffect>-3</baseMoodEffect>
       </li>
       <li>
-        <label>Clean</label>
+        <label>clean</label>
         <description>I feel fresh and clean.</description>
         <baseMoodEffect>3</baseMoodEffect>
       </li>
       <li>
-        <label>Squeaky Clean</label>
+        <label>squeaky clean</label>
         <description>I'm squeaky clean!</description>
         <baseMoodEffect>6</baseMoodEffect>
       </li>
@@ -33,12 +33,12 @@
     <workerClass>DubsBadHygiene.ThoughtWorker_Bowel</workerClass>
     <stages>
       <li>
-        <label>Bursting</label>
+        <label>bursting</label>
         <description>I need to go so bad I'm about to burst!</description>
         <baseMoodEffect>-6</baseMoodEffect>
       </li>
       <li>
-        <label>Need the bathroom</label>
+        <label>need the bathroom</label>
         <description>I need to go to the bathroom.</description>
         <baseMoodEffect>-3</baseMoodEffect>
       </li>

--- a/1.2/Defs/WorkGiverDefs/WorkGivers.xml
+++ b/1.2/Defs/WorkGiverDefs/WorkGivers.xml
@@ -3,7 +3,7 @@
 
   <WorkGiverDef>
     <defName>PlaceFertilizer</defName>
-    <label>Fertilize</label>
+    <label>fertilize</label>
     <giverClass>DubsBadHygiene.WorkGiver_PlaceFertilizer</giverClass>
     <workType>Growing</workType>
     <priorityInType>20</priorityInType>
@@ -31,7 +31,7 @@
 
   <WorkGiverDef>
     <defName>DBHAdministerFluids</defName>
-    <label>Administer Fluids</label>
+    <label>administer fluids</label>
     <giverClass>DubsBadHygiene.WorkGiver_AdministerFluids</giverClass>
     <workType>Doctor</workType>
     <verb>give drink</verb>
@@ -46,7 +46,7 @@
 
   <WorkGiverDef>
 		<defName>washPatient</defName>
-		<label>Wash Patient</label>
+		<label>wash patient</label>
 		<giverClass>DubsBadHygiene.WorkGiver_washPatient</giverClass>
 		<workType>Doctor</workType>
 		<verb>wash</verb>
@@ -59,7 +59,7 @@
 
   <WorkGiverDef>
     <defName>DocCleanBedpan</defName>
-    <label>Clean Bedpan</label>
+    <label>clean bed pan</label>
     <giverClass>DubsBadHygiene.WorkGiver_cleanBedpan</giverClass>
     <workType>Doctor</workType>
     <verb>clean</verb>
@@ -72,7 +72,7 @@
 
 	<WorkGiverDef>
 		<defName>cleanBedpan</defName>
-		<label>Clean Bedpan</label>
+		<label>clean bed pan</label>
 		<giverClass>DubsBadHygiene.WorkGiver_cleanBedpan</giverClass>
 		<workType>Cleaning</workType>
 		<verb>clean</verb>
@@ -85,10 +85,10 @@
 
   <WorkGiverDef>
     <defName>TipSewage</defName>
-    <label>Tip Sewage</label>
+    <label>tip sewage</label>
     <giverClass>DubsBadHygiene.WorkGiver_TipSewage</giverClass>
     <workType>BasicWorker</workType>
-    <verb>Tip Sewage</verb>
+    <verb>tip Sewage</verb>
     <gerund>tipping over</gerund>
     <canBeDoneWhileDrafted>true</canBeDoneWhileDrafted>
     <priorityInType>500</priorityInType>
@@ -96,11 +96,11 @@
 
   <WorkGiverDef>
     <defName>DrainWaterTank</defName>
-    <label>Drain Water</label>
+    <label>drain water</label>
     <giverClass>DubsBadHygiene.WorkGiver_DrainWater</giverClass>
     <workType>BasicWorker</workType>
-    <verb>Drain</verb>
-    <gerund>Draining</gerund>
+    <verb>drain</verb>
+    <gerund>draining</gerund>
     <canBeDoneWhileDrafted>true</canBeDoneWhileDrafted>
     <priorityInType>600</priorityInType>
   </WorkGiverDef>

--- a/1.2/Defs/WorkGiverDefs/WorkGiversHauling.xml
+++ b/1.2/Defs/WorkGiverDefs/WorkGiversHauling.xml
@@ -15,7 +15,7 @@
 
   <WorkGiverDef>
     <defName>DoBillsBurnPit</defName>
-    <label>do Burn Pit bills</label>
+    <label>do burn pit bills</label>
     <giverClass>WorkGiver_DoBill</giverClass>
     <workType>Hauling</workType>
     <priorityInType>40</priorityInType>
@@ -75,7 +75,7 @@
   
   <WorkGiverDef>
     <defName>UnloadComposter</defName>
-    <label>take compost out of the composter</label>
+    <label>take compost out of composter</label>
     <giverClass>DubsBadHygiene.WorkGiver_UnloadComposter</giverClass>
     <workType>Hauling</workType>
     <verb>take compost</verb>
@@ -101,7 +101,7 @@
   
   <WorkGiverDef>
     <defName>emptySepticTank</defName>
-    <label>Empty Septic Tank</label>
+    <label>empty septic tank</label>
     <giverClass>DubsBadHygiene.WorkGiver_emptySepticTank</giverClass>
     <workType>Hauling</workType>
     <verb>empty</verb>
@@ -114,7 +114,7 @@
   
   <WorkGiverDef>
     <defName>emptyLatrine</defName>
-    <label>Empty Latrine</label>
+    <label>empty latrine</label>
     <giverClass>DubsBadHygiene.WorkGiver_emptyLatrine</giverClass>
     <workType>Hauling</workType>
     <verb>empty</verb>
@@ -127,7 +127,7 @@
   
   <WorkGiverDef>
     <defName>RefillTub</defName>
-    <label>Refill Tub</label>
+    <label>refill tub</label>
     <giverClass>DubsBadHygiene.WorkGiver_RefillTub</giverClass>
     <workType>Hauling</workType>
     <verb>refill</verb>
@@ -140,7 +140,7 @@
 
   <WorkGiverDef>
     <defName>RefillWater</defName>
-    <label>Refill Water</label>
+    <label>refill water</label>
     <giverClass>DubsBadHygiene.WorkGiver_RefillWater</giverClass>
     <workType>Hauling</workType>
     <verb>refill</verb>

--- a/About/About.xml
+++ b/About/About.xml
@@ -4,11 +4,11 @@
 	<name>Dubs Bad Hygiene</name>
 	<author>Dubwise</author>
 	<url>https://github.com/Dubwise56/Dubs-Bad-Hygiene/wiki</url>
-	  <supportedVersions>
-    <li>1.0</li>
-      <li>1.1</li>
-	   <li>1.2</li>
-  </supportedVersions>
-  <packageId>Dubwise.DubsBadHygiene</packageId>
-	<description>Adds a sewage system, toilets, bathing, hygiene related needs and mood effects, central heating, water, irrigation, fertilizer, air conditioning, hot tubs, kitchen sinks, you name it!.</description>
+	<supportedVersions>
+		<li>1.0</li>
+		<li>1.1</li>
+		<li>1.2</li>
+	</supportedVersions>
+	<packageId>Dubwise.DubsBadHygiene</packageId>
+	<description>Adds a sewage system, toilets, bathing, hygiene-related needs and mood effects, central heating, water, irrigation, fertilizer, air conditioning, hot tubs, kitchen sinks, you name it!</description>
 </ModMetaData>

--- a/Languages/English/Keyed/DubsHygiene.xml
+++ b/Languages/English/Keyed/DubsHygiene.xml
@@ -3,146 +3,146 @@
 
   <!--New-->
   <PassiveWaterCoolersLink>Passive coolers use water</PassiveWaterCoolersLink>
-  <PassiveWaterCoolersLinkTip>Passive coolers have their wood fueling removed and are instead filled with water, similar to water tubs</PassiveWaterCoolersLinkTip>
+  <PassiveWaterCoolersLinkTip>Passive coolers have their wood fueling removed and are instead filled with water, similar to water tubs.</PassiveWaterCoolersLinkTip>
   <sos2int>SoS2 integration</sos2int>
-  <sos2intTip>Adds water and sewage processing to life support, and pipes to ship structures</sos2intTip>
-  <NoUnreservedSource>No unreserved water sources of the highest available quality</NoUnreservedSource>
+  <sos2intTip>Adds water and sewage processing to life support, and adds pipes to ship structures.</sos2intTip>
+  <NoUnreservedSource>No unreserved water sources of the highest available quality.</NoUnreservedSource>
   <AllowModdedDrinks>Allow modded drinks</AllowModdedDrinks>
-  <AllowModdedDrinksTip>Pawns will also be allowed to drink and pack any modded drinks, VGP and RimCuisine drinks can be used default, others will require modding an extension to the def</AllowModdedDrinksTip>
-  <AllowDrinkPacking>Pack Water Bottles</AllowDrinkPacking>
-  <AllowDrinkPackingTip>Pawns will automatically pack water bottles into their inventory when they can\n\nMay not work with some mods, for CE you will need to manually manage your loadout to include water bottles else they will keep dropping them!</AllowDrinkPackingTip>
-  <NeedsFilter>Needs Filter</NeedsFilter>
-  <MainFeatures>Main Features</MainFeatures>
-  <ExperimentalFeatures>Experimental Features</ExperimentalFeatures>
-  <DBHFalloutWarning>Fallout Water Contamination</DBHFalloutWarning>
+  <AllowModdedDrinksTip>Pawns will also be allowed to drink and pack any modded drinks. VGP and RimCuisine drinks can be used default, others will require modding an extension to the def.</AllowModdedDrinksTip>
+  <AllowDrinkPacking>Pack water bottles</AllowDrinkPacking>
+  <AllowDrinkPackingTip>Pawns will automatically pack water bottles into their inventory when they can.\n\nMay not work with some mods, for CE you will need to manually manage your loadout to include water bottles else they will keep dropping them.</AllowDrinkPackingTip>
+  <NeedsFilter>Needs filter</NeedsFilter>
+  <MainFeatures>Main features</MainFeatures>
+  <ExperimentalFeatures>Experimental features</ExperimentalFeatures>
+  <DBHFalloutWarning>Fallout water contamination</DBHFalloutWarning>
   <DBHFalloutWarningEx>After 2 days of toxic fallout the buildup will contaminate any water storage tanks connected to water wells.\n\nPrepare by creating a reserve of water and then using a valve to disconnect the wells to protect the water from contamination before it is too late.\n\nYou can also use a deep well to access uncontaminated water, or install a water treatment system which will eliminate all contamination from water reserves.</DBHFalloutWarningEx>
   <AllowAltDes>Allow modded categories</AllowAltDes>
-  <AllowAltDesTip>Allow other mods to change the buildings architect menu designation categories</AllowAltDesTip>
-  <RainIrrigation>Rain Irrigation</RainIrrigation>
-  <RainIrrigationTip>Rain will give the same boost as sprinklers, might reduce performance</RainIrrigationTip>
+  <AllowAltDesTip>Allow other mods to change the buildings architect menu designation categories.</AllowAltDesTip>
+  <RainIrrigation>Rain irrigation</RainIrrigation>
+  <RainIrrigationTip>Rain will give the same boost as sprinklers. Might reduce game performance.</RainIrrigationTip>
   <GrowingZoneNotAllowed>Growing zone sowing disabled</GrowingZoneNotAllowed>
-  <NoFertilizerFound>No Fertilizer Found</NoFertilizerFound>
-  <AreaPlaceFertilizer>Fertilizer Area</AreaPlaceFertilizer>
-  <AreaPlaceFertilizerDesc>Designate areas to fertilize with biosolids</AreaPlaceFertilizerDesc>
+  <NoFertilizerFound>No fertilizer found</NoFertilizerFound>
+  <AreaPlaceFertilizer>Fertilizer area</AreaPlaceFertilizer>
+  <AreaPlaceFertilizerDesc>Designate areas to fertilize with biosolids.</AreaPlaceFertilizerDesc>
   <AddFertilizerArea>Add area</AddFertilizerArea>
   <RemoveFertilizerArea>Remove area</RemoveFertilizerArea>
-  <StockpileWater>Stockpile Water x{0}</StockpileWater>
+  <StockpileWater>Stockpile water x{0}</StockpileWater>
   <HygieneWiki>Bad Hygiene Wiki</HygieneWiki>
-  <HygieneWikiDesc>Go to the bad hygiene wiki</HygieneWikiDesc>
-  <SurvivalMode>Survival Mode</SurvivalMode>
-  <SurvivalModeTip>Limits the default shallow water grid generation to very small patches, terrain features no longer generate water, and the radius around surface water is reduced\n\nA new game is not required, works with saves</SurvivalModeTip>
+  <HygieneWikiDesc>Go to the Bad Hygiene Wiki</HygieneWikiDesc>
+  <SurvivalMode>Survival mode</SurvivalMode>
+  <SurvivalModeTip>Limits the default shallow water grid generation to very small patches. Terrain features no longer generate water, and the radius around surface water is reduced.\n\nA new game is not required; works with existing saves.</SurvivalModeTip>
   <HydroponicsLink>Hydroponics</HydroponicsLink>
-  <HydroponicsLinkTip>Powered growing buildings like hydroponics have water tanks that require filling from pipes, plants die from lack of water instead of power, water tanks only fill when the building is powered</HydroponicsLinkTip>
-  <ThirstRequiresRestart>A restart is required to add and remove thirst related items\n\n restart now?</ThirstRequiresRestart>
+  <HydroponicsLinkTip>Powered growing buildings like hydroponics have water tanks that require filling from pipes. Plants die from lack of water instead of power, but water tanks only fill when the building is powered.</HydroponicsLinkTip>
+  <ThirstRequiresRestart>A restart is required to add and remove thirst-related items.\n\nRestart now?</ThirstRequiresRestart>
 
   <!--Construction-->
-  <DesignatorRemovePlumbing>Remove Pipes</DesignatorRemovePlumbing>
-  <DesignatorRemovePlumbingDesc>Designate sections of a pipe type for deconstruction</DesignatorRemovePlumbingDesc>
-  <RemoveSewage>Remove Sewage</RemoveSewage>
-  <RemoveSewageDesc>Remove sewage from the ground and place it into barrels</RemoveSewageDesc>
-  <RemovePlumbing>Remove Plumbing</RemovePlumbing>
-  <RemoveAirCon>Remove Air-Con</RemoveAirCon>
-  <DesignatorPaintFixtures>Paint Fixtures</DesignatorPaintFixtures>
-  <DesignatorPaintFixturesDesc>Paint bathroom fixtures and radiators</DesignatorPaintFixturesDesc>
+  <DesignatorRemovePlumbing>Remove pipes</DesignatorRemovePlumbing>
+  <DesignatorRemovePlumbingDesc>Designate sections of a pipe type for deconstruction.</DesignatorRemovePlumbingDesc>
+  <RemoveSewage>Remove sewage</RemoveSewage>
+  <RemoveSewageDesc>Remove sewage from the ground and place it into barrels.</RemoveSewageDesc>
+  <RemovePlumbing>Remove plumbing</RemovePlumbing>
+  <RemoveAirCon>Remove air-con</RemoveAirCon>
+  <DesignatorPaintFixtures>Paint fixtures</DesignatorPaintFixtures>
+  <DesignatorPaintFixturesDesc>Paint bathroom fixtures and radiators.</DesignatorPaintFixturesDesc>
   <PaintFixtures>Paint</PaintFixtures>
   <StripPaint>Strip</StripPaint>
 
   
   
   <!--Warnings-->
-  <Alert_MissingTower>Missing Water Tower</Alert_MissingTower>
-  <Alert_MissingTowerDesc>A water tower or water butt is required to store water pumped from wells</Alert_MissingTowerDesc>
-  <Alert_MissingWell>Missing Well</Alert_MissingWell>
-  <Alert_MissingWellDesc>Pumps require a piped well to access ground water</Alert_MissingWellDesc>
-  <Alert_MissingPump>Missing Water Pump</Alert_MissingPump>
-  <Alert_MissingPumpDesc>A water pump is required to pump the water from a well to a water tower</Alert_MissingPumpDesc>
+  <Alert_MissingTower>Missing water tower</Alert_MissingTower>
+  <Alert_MissingTowerDesc>A water tower or water butt is required to store water pumped from wells.</Alert_MissingTowerDesc>
+  <Alert_MissingWell>Missing well</Alert_MissingWell>
+  <Alert_MissingWellDesc>Pumps require a piped well to access ground water.</Alert_MissingWellDesc>
+  <Alert_MissingPump>Missing water pump</Alert_MissingPump>
+  <Alert_MissingPumpDesc>A water pump is required to pump the water from a well to a water tower.</Alert_MissingPumpDesc>
 
-  <LowCoolingCap>Low cooling capacity, you can increase the power of outdoor units</LowCoolingCap>
-  <NotOwned>Access Restricted</NotOwned>
-  <GenderRestricted>{0} Only</GenderRestricted>
-  <PrisonersOnly>Prisoners Only</PrisonersOnly>
-  <BlockedSewage>Blocked Sewage Outlet</BlockedSewage>
+  <LowCoolingCap>Low cooling capacity. You can increase the power of outdoor units.</LowCoolingCap>
+  <NotOwned>Access restricted</NotOwned>
+  <GenderRestricted>{0} only</GenderRestricted>
+  <PrisonersOnly>Prisoners only</PrisonersOnly>
+  <BlockedSewage>Blocked sewage outlet</BlockedSewage>
   <BlockedSewageDesc>Sewage has built up around the drain hole and is blocking the outlet.\n\nBuild more outlets or add a septic tank to create a buffer and reduce pressure on the outlets.</BlockedSewageDesc>
-  <LowWaterTemp>Low Water Temp</LowWaterTemp>
+  <LowWaterTemp>Low water temp</LowWaterTemp>
   <LowWaterTempDesc>The water temperature in this tank is too low; colonists expecting to use hot water may get annoyed.\n\nTurn on boilers, increase the heating capacity, or add another hot water tank.</LowWaterTempDesc>
   <WellNeedsWater>Must be placed over a cell with ground water.</WellNeedsWater>
-  <AssigningRequiresRoom>The fixture must be inside a room to restrict it</AssigningRequiresRoom>
-  <NoWaterTowers>Requires Water Storage Tower</NoWaterTowers>
-  <AssigningRequiresBladderNeed>Assigning requires bladder need, {0} doesn't have it</AssigningRequiresBladderNeed>
+  <AssigningRequiresRoom>The fixture must be inside a room to restrict it.</AssigningRequiresRoom>
+  <NoWaterTowers>Requires water storage tower</NoWaterTowers>
+  <AssigningRequiresBladderNeed>Assigning requires bladder need, but {0} doesn't have bladder need.</AssigningRequiresBladderNeed>
 
   <NoCompostingMaterial>No composting material</NoCompostingMaterial>
   <Nowater>No water capacity</Nowater>
   <Nosewage>No sewage capacity</Nosewage>
-  <RequiresPlumbing>Requires Plumbing</RequiresPlumbing>
-  <AccessRestricted>Access Restricted</AccessRestricted>
+  <RequiresPlumbing>Requires plumbing</RequiresPlumbing>
+  <AccessRestricted>Access restricted</AccessRestricted>
 
-  <TooHot>Too Hot: x{0}</TooHot>
-  <InRain>In Rain: x{0}</InRain>
+  <TooHot>Too hot: x{0}</TooHot>
+  <InRain>In rain: x{0}</InRain>
   <PhysicalActivity>Exertion: x{0}</PhysicalActivity>
   <FilthyRoom>Room: x{0}</FilthyRoom>
   <TotalHygieneStat>Total: x{0}</TotalHygieneStat>
-  <DirtyHands>Dirty Hands - Disease risk</DirtyHands>
+  <DirtyHands>Dirty hands - Disease risk</DirtyHands>
   <Contaminated>Contaminated - Disease risk</Contaminated>
 
-  <LetterLabelBlockedDrain>Blocked Drain</LetterLabelBlockedDrain>
+  <LetterLabelBlockedDrain>Blocked drain</LetterLabelBlockedDrain>
   <LetterBlockedDrain>A drain has become blocked. A cleaner must clean the blockage.</LetterBlockedDrain>
 
-  <ContaminationAlert>Contaminated Water</ContaminationAlert>
-  <ContaminationAlertDesc>A well has become polluted. \n\nSources of contamination:\n{0} \n\nEither move the well, remove the sources of contamination, or if you are using piped wells add a water treatment system, which will also clean contaminated water towers over time.</ContaminationAlertDesc>
-  <ContaminatiedTowerAlert>Contaminated Water Tower</ContaminatiedTowerAlert>
-  <ContaminatiedTowerAlertDesc>A water tower has become polluted, posing a serious health risk to your colonists! You must solve the cause of the pollution, then drain the tank or build a water treatment system.</ContaminatiedTowerAlertDesc>
+  <ContaminationAlert>Contaminated water</ContaminationAlert>
+  <ContaminationAlertDesc>A well has become polluted.\n\nSources of contamination:\n{0}\n\nEither move the well, remove the sources of contamination, or if you are using piped wells add a water treatment system, which will also clean contaminated water towers over time.</ContaminationAlertDesc>
+  <ContaminatiedTowerAlert>Contaminated water tower</ContaminatiedTowerAlert>
+  <ContaminatiedTowerAlertDesc>A water tower has become polluted, posing a serious health risk to your colonists. Solve the cause of the pollution and then drain the tank, or build a water treatment system.</ContaminatiedTowerAlertDesc>
 
   <MessageHygieneDisease>{0} has contracted {1} from bad hygiene</MessageHygieneDisease>
   <MessageWaterDisease>{0} has contracted {1} from dirty water</MessageWaterDisease>
   
   <!--Restrictions-->
-  <ChangeGenderRestriction>Change Gender Restriction</ChangeGenderRestriction>
+  <ChangeGenderRestriction>Change gender restriction</ChangeGenderRestriction>
   <CommandFixtureSetAsMedicalLabel>Medical</CommandFixtureSetAsMedicalLabel>
-  <CommandFixtureSetAsMedicalDesc>Limit this fixture to patients only</CommandFixtureSetAsMedicalDesc>
+  <CommandFixtureSetAsMedicalDesc>Limit this fixture to patients only.</CommandFixtureSetAsMedicalDesc>
   <PatientsOnly>Patients only</PatientsOnly>
-  <AttackHelicopter>Attack Helicopter</AttackHelicopter>
+  <AttackHelicopter>Attack helicopter</AttackHelicopter>
   <Unisex>Unisex</Unisex>
-  <ConnectFixturesToBed>Link Bed</ConnectFixturesToBed>
-  <ConnectFixturesToBedDesc>Connect the fixtures to a nearby bed so they inherit the ownership</ConnectFixturesToBedDesc>
-  <CancelConnectFixturesToBed>Clear Bed Link</CancelConnectFixturesToBed>
+  <ConnectFixturesToBed>Link bed</ConnectFixturesToBed>
+  <ConnectFixturesToBedDesc>Connect the fixtures to a nearby bed so they inherit the ownership.</ConnectFixturesToBedDesc>
+  <CancelConnectFixturesToBed>Clear bed link</CancelConnectFixturesToBed>
   <CancelConnectFixturesToBedDesc>Clear the link to beds</CancelConnectFixturesToBedDesc>
 
 
   <!--Heating-->
-  <WaterTemp>Water Temp: {0}</WaterTemp>
-  <ConnectedHeatingCapacity>Connected Demand/Capacity: {0}/{1} U ({2})</ConnectedHeatingCapacity>
-  <ConnectedCoolingCapacity>Connected Demand/Capacity: {0}/{1} U ({2})</ConnectedCoolingCapacity>
-  <HeatingUnits>Heating Usage: {0} U</HeatingUnits>
-  <CoolingUnits>Cooling Usage: {0} U</CoolingUnits>
-  <HeatingMode>Heating Units/Power: {0} U / {1} W</HeatingMode>
-  <CoolingMode>Cooling Units/Power: {0} U / {1} W</CoolingMode>
+  <WaterTemp>Water temp: {0}</WaterTemp>
+  <ConnectedHeatingCapacity>Connected demand/capacity: {0}/{1} U ({2})</ConnectedHeatingCapacity>
+  <ConnectedCoolingCapacity>Connected demand/capacity: {0}/{1} U ({2})</ConnectedCoolingCapacity>
+  <HeatingUnits>Heating usage: {0} U</HeatingUnits>
+  <CoolingUnits>Cooling usage: {0} U</CoolingUnits>
+  <HeatingMode>Heating units/power: {0} U / {1} W</HeatingMode>
+  <CoolingMode>Cooling units/power: {0} U / {1} W</CoolingMode>
   <CoolingEfficiencyGood>Efficiency: {0}</CoolingEfficiencyGood>
-  <CoolingEfficiencyBad>Efficiency: {0} Overheating</CoolingEfficiencyBad>
-  <TargetTemp>Minimum Temp: {0}</TargetTemp>
-  <LowerPower>Reduce Power</LowerPower>
-  <LowerPowerDesc>Reduce the heating capacity</LowerPowerDesc>
-  <RaisePower>Increase Power</RaisePower>
-  <RaisePowerDesc>Increase the heating capacity</RaisePowerDesc>
-  <HotwaterCapacity>Hot Water Capacity: {0}</HotwaterCapacity>
-  <OverrideThermostat>Override Thermostat</OverrideThermostat>
-  <OverrideThermostatDesc>Force the boiler to run continuously</OverrideThermostatDesc>
+  <CoolingEfficiencyBad>Efficiency: {0} overheating</CoolingEfficiencyBad>
+  <TargetTemp>Minimum temp: {0}</TargetTemp>
+  <LowerPower>Reduce power</LowerPower>
+  <LowerPowerDesc>Reduce the heating capacity.</LowerPowerDesc>
+  <RaisePower>Increase power</RaisePower>
+  <RaisePowerDesc>Increase the heating capacity.</RaisePowerDesc>
+  <HotwaterCapacity>Hot water capacity: {0}</HotwaterCapacity>
+  <OverrideThermostat>Override thermostat</OverrideThermostat>
+  <OverrideThermostatDesc>Force the boiler to run continuously.</OverrideThermostatDesc>
   <MustPlaceFreezerWithFreeSpaces>Exhaust vents must be kept clear!</MustPlaceFreezerWithFreeSpaces>
   <SolarEfficiencyCold>Too cold</SolarEfficiencyCold>
   <SolarEfficiencyRoof>Roofed</SolarEfficiencyRoof>
-  <SolarEfficiencyGood>Heating Units/Efficiency: {0}/{1}</SolarEfficiencyGood>
-  <RadCurrentCap>Radiator Temp: {0}</RadCurrentCap>
-  <ThermostatSetupWarning>Thermostat overridden by hot water tanks...\nset all connected hot water tanks to thermostat mode!</ThermostatSetupWarning>
-  <HotWaterTankUseThermostat>Thermostat Control</HotWaterTankUseThermostat>
-  <HotWaterTankUseThermostatDesc>Turn on boilers for 1 hour when the tank temperature is low, if this is disabled then boilers will run continuously and ignore room thermostats</HotWaterTankUseThermostatDesc>
+  <SolarEfficiencyGood>Heating units (efficiency): {0} U ({1})</SolarEfficiencyGood>
+  <RadCurrentCap>Radiator temp: {0}</RadCurrentCap>
+  <ThermostatSetupWarning>Thermostat overridden by hot water tanks. Set all connected hot water tanks to thermostat mode.</ThermostatSetupWarning>
+  <HotWaterTankUseThermostat>Thermostat control</HotWaterTankUseThermostat>
+  <HotWaterTankUseThermostatDesc>Turn on boilers for 1 hour when the tank temperature is low. If this is disabled then boilers will run continuously and ignore room thermostats.</HotWaterTankUseThermostatDesc>
 
   <!--Hygiene-->
-  <WashHands>Wash Hands</WashHands>
+  <WashHands>Wash hands</WashHands>
   <Wash>Wash</Wash>
   <UseToilet>Use</UseToilet>
   <SewageUsage>Usage = {0}</SewageUsage>
   <MustBePlumbing>Must be plumbing</MustBePlumbing>
-  <BlockedDrain>Blocked Drain</BlockedDrain>
-  <PlumbOrEmpty>Plumb Or Empty the Latrine</PlumbOrEmpty>
+  <BlockedDrain>Blocked drain</BlockedDrain>
+  <PlumbOrEmpty>Plumb or empty the latrine</PlumbOrEmpty>
   <WashingMachineSpinning>Running...</WashingMachineSpinning>
   <WashingMachineUnload>Unload now</WashingMachineUnload>
   <WashingMachineLoad>Load: {0}/{1}</WashingMachineLoad>
@@ -151,86 +151,86 @@
 
   <!--Water-->
   <dbhDrink>Drink</dbhDrink>
-  <CommandDesignateOpenCloseValveLabel>Toggle Valve</CommandDesignateOpenCloseValveLabel>
-  <CommandDesignateOpenCloseValveDesc>Toggle the valve open or closed</CommandDesignateOpenCloseValveDesc>
-  <ValveClosed>Valve Closed</ValveClosed>
+  <CommandDesignateOpenCloseValveLabel>Toggle valve</CommandDesignateOpenCloseValveLabel>
+  <CommandDesignateOpenCloseValveDesc>Toggle the valve between open and closed.</CommandDesignateOpenCloseValveDesc>
+  <ValveClosed>Valve closed</ValveClosed>
 
-  <PumpCapacity>Pump Capacity: {0} L/day</PumpCapacity>
-  <GroundCapacity>Ground Capacity: {0} L/day</GroundCapacity>
-  <PipedPumpCapacity>Piped Pump/Ground Capacity: {0}/{1} L/day ({2})</PipedPumpCapacity>
+  <PumpCapacity>Pump capacity: {0} L/day</PumpCapacity>
+  <GroundCapacity>Ground capacity: {0} L/day</GroundCapacity>
+  <PipedPumpCapacity>Piped pump/Ground capacity: {0}/{1} L/day ({2})</PipedPumpCapacity>
 
-  <WaterStorage>Water Stored: {0} L</WaterStorage>
-  <TotalWaterStorage>Piped Water Stored: {0} L</TotalWaterStorage>
+  <WaterStorage>Water stored: {0} L</WaterStorage>
+  <TotalWaterStorage>Piped water stored: {0} L</TotalWaterStorage>
 
-  <PollutionLevel>Pollution Level: {0}</PollutionLevel>
+  <PollutionLevel>Pollution level: {0}</PollutionLevel>
 
   <CommandSprinkleDown>Decrease radius</CommandSprinkleDown>
   <CommandSprinkleUp>Increase radius</CommandSprinkleUp>
-  <UntreatedWater>Quality: Untreated - small disease risk</UntreatedWater>
-  <ContaminatedWater>Quality: Contaminated - high disease risk!</ContaminatedWater>
-  <TreatedWater>Quality: Treated - safe</TreatedWater>
+  <UntreatedWater>Quality: Untreated - Small disease risk</UntreatedWater>
+  <ContaminatedWater>Quality: Contaminated - High disease risk!</ContaminatedWater>
+  <TreatedWater>Quality: Treated - Safe</TreatedWater>
 
-  <DrainTank>Drain Tank</DrainTank>
-  <DrainTankDesc>Drain the tank and remove contamination</DrainTankDesc>
+  <DrainTank>Drain tank</DrainTank>
+  <DrainTankDesc>Drain the tank and remove contamination.</DrainTankDesc>
 
-  <WaterValueOffset>Water value: {0} for {1}L</WaterValueOffset>
+  <WaterValueOffset>Water value: {0} for {1} L</WaterValueOffset>
   <HyWater>Water</HyWater>
   <!--Sewage-->
 
   <DrainSepticTank>Drain</DrainSepticTank>
-  <DrainSepticTankDesc>Set the level at which fecal sludge should be emptied into barrels, which can be moved and knocked over, burned, or turned into biosolids</DrainSepticTankDesc>
-  <SewageProcessing>Treating: {0} L/d Holding: {1} L ({2})</SewageProcessing>
+  <DrainSepticTankDesc>Set the level at which fecal sludge should be emptied into barrels. Fecal sludge can be moved and knocked over, burned, or turned into biosolids.</DrainSepticTankDesc>
+  <SewageProcessing>Treating: {0} L/d. Holding: {1} L ({2})</SewageProcessing>
   <DoNotDrainTank>Do not drain</DoNotDrainTank>
   <DrainSepticTankAt>Drain tank at {0}</DrainSepticTankAt>
 
   <PitCapacity>Pit: {0}</PitCapacity>
   <PitFull>Pit is full, empty now!</PitFull>
-  <KickOver>Kick Over</KickOver>
-  <KickOverDesc>Spill this barrel of sewage on the ground</KickOverDesc>
+  <KickOver>Kick over</KickOver>
+  <KickOverDesc>Spill this barrel of sewage on the ground.</KickOverDesc>
 
   <!--Composting-->
-  <ContainsCompost>Contains Compost {0}/{1}</ContainsCompost>
-  <ContainsFecalSludge>Contains Fecal Sludge {0}/{1}</ContainsFecalSludge>
+  <ContainsCompost>Contains compost: {0}/{1} L</ContainsCompost>
+  <ContainsFecalSludge>Contains fecal sludge: {0}/{1} L</ContainsFecalSludge>
   <Composted>Composted</Composted>
-  <CompostingProgress>Composting Progress {0} ({1})</CompostingProgress>
-  <ComposterOutOfIdealTemperature>Composter Out Of Ideal Temperature</ComposterOutOfIdealTemperature>
-  <IdealCompostingTemperature>Ideal Composting Temperature</IdealCompostingTemperature>
+  <CompostingProgress>Composting progress: {0} ({1})</CompostingProgress>
+  <ComposterOutOfIdealTemperature>Composter has non-ideal temperature</ComposterOutOfIdealTemperature>
+  <IdealCompostingTemperature>Ideal composting temperature</IdealCompostingTemperature>
 
 
   <!--Mod Options-->
 
-  <QuitToMenuToChange>Quit to main menu to change</QuitToMenuToChange>
-  <RimefellerLink>Rimefeller Link</RimefellerLink>
-  <RimefellerLinkTip>Enable water usage on crackers and refiners in Rimefeller</RimefellerLinkTip>
-  <RimatomicsLink>Rimatomics Link</RimatomicsLink>
-  <RimatomicsLinkTip>Enable water usage on cooling towers in Rimatomics</RimatomicsLinkTip>
-  <OverrideNeedSettingsTip>Manually disable needs by body type, race, or active hediff</OverrideNeedSettingsTip>
+  <QuitToMenuToChange>Quit to main menu to change.</QuitToMenuToChange>
+  <RimefellerLink>Rimefeller link</RimefellerLink>
+  <RimefellerLinkTip>Enable water usage on crackers and refiners in Rimefeller.</RimefellerLinkTip>
+  <RimatomicsLink>Rimatomics link</RimatomicsLink>
+  <RimatomicsLinkTip>Enable water usage on cooling towers in Rimatomics.</RimatomicsLinkTip>
+  <OverrideNeedSettingsTip>Manually disable needs by body type, race, or active hediff.</OverrideNeedSettingsTip>
   <OverrideNeedsSettings>Needs filter</OverrideNeedsSettings>
   <Disablebladderneed>Disable bladder need</Disablebladderneed>
   <Disablehygieneneed>Disable hygiene need</Disablehygieneneed>
   <DisableNeedsLabel>Needs</DisableNeedsLabel>
   <NeedCheckboxTip>Tick to enable</NeedCheckboxTip>
   <PrisonersGetNeeds>Prisoners</PrisonersGetNeeds>
-  <PrisonersGetNeedsTip>If prisoners will get the needs</PrisonersGetNeedsTip>
+  <PrisonersGetNeedsTip>Should prisoners have needs?</PrisonersGetNeedsTip>
   <HospitalityGuestsGetNeeds>Guests</HospitalityGuestsGetNeeds>
-  <HospitalityGuestsGetNeedsTip>If guests should get the needs</HospitalityGuestsGetNeedsTip>
+  <HospitalityGuestsGetNeedsTip>Should guests have needs?</HospitalityGuestsGetNeedsTip>
   <PrivacyChecks>Privacy</PrivacyChecks>
-  <PrivacyChecksTip>Colonists care about privacy when bathing or using toilets</PrivacyChecksTip>
-  <CoolingEfficiency>Cooling Efficiency</CoolingEfficiency>
-  <CoolingEfficiencyTip>Should high temperature affect cooling efficiency like standard AC</CoolingEfficiencyTip>
+  <PrivacyChecksTip>Colonists care about privacy when bathing or using toilets.</PrivacyChecksTip>
+  <CoolingEfficiency>Cooling efficiency</CoolingEfficiency>
+  <CoolingEfficiencyTip>Should high temperature affect cooling efficiency like standard AC?</CoolingEfficiencyTip>
 
   <DisableNeeds>Toggle needs</DisableNeeds>
-  <DisableNeedsTip>Disable the needs entirely, overrides all other settings</DisableNeedsTip>
+  <DisableNeedsTip>Disable needs entirely. Overrides all other settings.</DisableNeedsTip>
   
   <PetsGetBladder>Pet bladders</PetsGetBladder>
-  <PetsGetBladderTip>Enable bladder need on pets, also adds litter boxes for pets</PetsGetBladderTip>
-  <WildAnimalsGetBladder>Wild Animal bladders</WildAnimalsGetBladder>
-  <WildAnimalsGetBladderTip>Enable bladder need on all wild animals, this could get messy</WildAnimalsGetBladderTip>
-  <ThirstNeed>Thirst Need</ThirstNeed>
-  <ThirstNeedTip>Enable a thirst need on all colonists with the bladder need, adds drinking fountains and water bottles, requires a restart</ThirstNeedTip>
-  <FertilizerVisible>Fertilizer Visible</FertilizerVisible>
-  <FertilizerVisibleTip>Should the fertilizer grid be visible</FertilizerVisibleTip>
-  <AllowNonHuman>Non Human Colonists</AllowNonHuman>
-  <AllowNonHumanTip>Allow the needs on non human colonists, you can disable specific beings with the override settings</AllowNonHumanTip>
+  <PetsGetBladderTip>Enable bladder need on pets. Also adds litter boxes for pets.</PetsGetBladderTip>
+  <WildAnimalsGetBladder>Wild animal bladders</WildAnimalsGetBladder>
+  <WildAnimalsGetBladderTip>Enable bladder need on all wild animals. This could get messy.</WildAnimalsGetBladderTip>
+  <ThirstNeed>Thirst need</ThirstNeed>
+  <ThirstNeedTip>Enable thirst need on all colonists with bladder need. Adds drinking fountains and water bottles. Requires a restart.</ThirstNeedTip>
+  <FertilizerVisible>Fertilizer visible</FertilizerVisible>
+  <FertilizerVisibleTip>Should the fertilizer grid be visible?</FertilizerVisibleTip>
+  <AllowNonHuman>Non-human colonists</AllowNonHuman>
+  <AllowNonHumanTip>Enables needs on non-human colonists. You can disable specific beings with the needs filter.</AllowNonHumanTip>
 
 </LanguageData>


### PR DESCRIPTION
Bad Hygiene is an excellent mod, but uses a different capitalisation style than the base game. As a result, the mod looks a bit sloppy to the end user even though it isn't. I have changed the capitalisation style for all displayed text to match that of the base game so that it looks like the mod might as well have been a part of the base game.

## Examples
Consider the following examples of the changes I have made. Each time, I show what the mod looks like without this PR, with this PR, and what the base game looks like in a similar case.

| Before | After | Base game |
| --- | --- | --- |
| ![Recipe (before)](https://user-images.githubusercontent.com/13442533/94956204-0eaddb80-04ec-11eb-8348-23c8f4238c10.png) | ![Recipe (after)](https://user-images.githubusercontent.com/13442533/94956212-10779f00-04ec-11eb-916d-64c6c94aa561.png) | ![Recipe (base game)](https://user-images.githubusercontent.com/13442533/94956218-12416280-04ec-11eb-8833-252374653125.png) |
| ![Activity (before)](https://user-images.githubusercontent.com/13442533/94956457-7e23cb00-04ec-11eb-99cb-b33dbea4408d.png) | ![Activity (after)](https://user-images.githubusercontent.com/13442533/94956463-7fed8e80-04ec-11eb-91be-11d5043a89af.png) | ![Activity (base game)](https://user-images.githubusercontent.com/13442533/94956466-81b75200-04ec-11eb-8368-ec7c4c0f389b.png) |
| ![Tower information (before)](https://user-images.githubusercontent.com/13442533/94955877-8cbdb280-04eb-11eb-9e33-69cbe7898f4b.png) | ![Tower information (after)](https://user-images.githubusercontent.com/13442533/94955910-96dfb100-04eb-11eb-8d54-a1ebe96874cb.png) | ![Tower information (base game)](https://user-images.githubusercontent.com/13442533/94955926-9fd08280-04eb-11eb-8a12-f2e483c7297c.png) |
| ![Architect menu (before)](https://user-images.githubusercontent.com/13442533/94955966-b24abc00-04eb-11eb-8bf3-a5ce8eedac0f.png) | ![Architect menu (after)](https://user-images.githubusercontent.com/13442533/94955981-b676d980-04eb-11eb-8656-0cfdcab09ac5.png) | ![Architect menu (base game)](https://user-images.githubusercontent.com/13442533/94955995-ba0a6080-04eb-11eb-9c1b-79bb704e5f55.png) |
| ![Mod settings (before)](https://user-images.githubusercontent.com/13442533/94956080-da3a1f80-04eb-11eb-85be-9897b5b70d15.png) | ![Mod settings (after)](https://user-images.githubusercontent.com/13442533/94956085-dc9c7980-04eb-11eb-9236-df7d129f2b09.png) | ![Settings (base game)](https://user-images.githubusercontent.com/13442533/94956174-ffc72900-04eb-11eb-8f9d-2d1b247bc811.png) |
| ![Research tree (before)](https://user-images.githubusercontent.com/13442533/94956254-28e7b980-04ec-11eb-9a0a-15026859cdef.png) | ![Research tree (after)](https://user-images.githubusercontent.com/13442533/94956262-2b4a1380-04ec-11eb-8936-7a0becfef21c.png) | ![Research tree (reference)](https://user-images.githubusercontent.com/13442533/94956268-2dac6d80-04ec-11eb-96b6-d0e1db0096b4.png) |

## Changes
I **did not** do any of the following:
* Change languages other than English
* Change defNames, paths, types, etc.
* Change text for versions 1.0 and 1.1. I can still do this if desired.

I **did** do the following:
* Add periods to the end of descriptions and tips.
* Remove periods from the end of activities.
* Add more interpunction in run-on sentences.
* Change all labels to lowercase
  * This looks better when used in a sentence, e.g. "Using shower" instead of "Using Shower".
  * Note that the game always capitalises the first letter of the label when used outside of a sentence, as seen in the "Hot water tank" example.
  * Letter labels (used in incidents) still have the first letter capitalised.

## Note
[A comment](https://github.com/Dubwise56/Dubs-Bad-Hygiene/blob/051f76f13d378f444efaa19fd4daeba7c2c7adda/1.2/Defs/NeedDefs/Needs_Misc.xml#L50) mentions that the names of needs should not be changed. I assumed that this was about changing the `defName` and not about the `label`. **I have changed the label of the thirst need.**
