### PR TITLE
Resolve missing adjustments from my previous PR

### DIFF
--- a/1.2/Defs/Effects/Mote_Visual.xml
+++ b/1.2/Defs/Effects/Mote_Visual.xml
@@ -3,7 +3,7 @@
 
   <ThingDef>
     <thingClass>MoteThrown</thingClass>
-    <label>Mote</label>
+    <label>mote</label>
     <category>Mote</category>
     <graphicData>
 	      <texPath>DBH/Things/Mote/FecalBit</texPath>
@@ -25,7 +25,7 @@
 
   <ThingDef Name="BasedMote" Abstract="True">
     <thingClass>MoteThrown</thingClass>
-    <label>Mote</label>
+    <label>mote</label>
     <category>Mote</category>
     <graphicData>
       <graphicClass>Graphic_Mote</graphicClass>

--- a/1.2/Defs/Joy/JoyGivers.xml
+++ b/1.2/Defs/Joy/JoyGivers.xml
@@ -3,7 +3,7 @@
 
   <JoyKindDef>
     <defName>Hydrotherapy</defName>
-    <label>Hydrotherapy</label>
+    <label>hydrotherapy</label>
   </JoyKindDef>
 
   <JobDef>

--- a/1.2/Defs/ThingDefs_Buildings/BuildingsB_Hygiene.xml
+++ b/1.2/Defs/ThingDefs_Buildings/BuildingsB_Hygiene.xml
@@ -422,7 +422,7 @@
   
   <ThingDef ParentName="DubsDirtyBasinBase">
     <defName>BasinStuff</defName>
-    <label>Basin</label>
+    <label>basin</label>
     <stuffCategories>
       <li>Metallic</li>
       <li>Woody</li>

--- a/Languages/English/Keyed/DubsHygiene.xml
+++ b/Languages/English/Keyed/DubsHygiene.xml
@@ -61,7 +61,7 @@
   <NotOwned>Access restricted</NotOwned>
   <GenderRestricted>{0} only</GenderRestricted>
   <PrisonersOnly>Prisoners only</PrisonersOnly>
-  <BlockedSewage>Blocked sewage outlet</BlockedSewage>
+  <BlockedSewage>A sewage outlet has become blocked.</BlockedSewage>
   <BlockedSewageDesc>Sewage has built up around the drain hole and is blocking the outlet.\n\nBuild more outlets or add a septic tank to create a buffer and reduce pressure on the outlets.</BlockedSewageDesc>
   <LowWaterTemp>Low water temp</LowWaterTemp>
   <LowWaterTempDesc>The water temperature in this tank is too low; colonists expecting to use hot water may get annoyed.\n\nTurn on boilers, increase the heating capacity, or add another hot water tank.</LowWaterTempDesc>
@@ -84,7 +84,7 @@
   <DirtyHands>Dirty hands - Disease risk</DirtyHands>
   <Contaminated>Contaminated - Disease risk</Contaminated>
 
-  <LetterLabelBlockedDrain>Blocked drain</LetterLabelBlockedDrain>
+  <LetterLabelBlockedDrain>A drain has become blocked.</LetterLabelBlockedDrain>
   <LetterBlockedDrain>A drain has become blocked. A cleaner must clean the blockage.</LetterBlockedDrain>
 
   <ContaminationAlert>Contaminated water</ContaminationAlert>


### PR DESCRIPTION
My previous PR (#35) made capitalisation and punctuation more consistent with the base game. I found that I missed a few instances, which are fixed by this PR.

In this PR, I have changed the following:
* Changed labels to lowercase where I had forgotten to do so, like with the basin.
* Add a period at the end of the blocked drain alert, like in the base game. See for example the base game screenshot below. While the i18n key is `LetterLabelBlockedDrain`, the message is not displayed as a letter label. If it is ever changed back to a letter label, the old string ("Blocked drain") should be used again.

| Base game | After this PR |
|---|---|
| ![Alert punctuation in base game](https://user-images.githubusercontent.com/13442533/95675114-f9544380-0bb4-11eb-9fa0-2cf24632735f.png) | ![Alert punctuation after this PR](https://user-images.githubusercontent.com/13442533/95675118-08d38c80-0bb5-11eb-8bf2-0e36d658b133.png) |
