### PR TITLE
Set extraNonDraftedPerceivedPathCost for PoolWater

### DIFF
--- a/1.6/Defs/ThingDefs_Buildings/BuildingsC_Joy.xml
+++ b/1.6/Defs/ThingDefs_Buildings/BuildingsC_Joy.xml
@@ -108,7 +108,7 @@
 		<extraDeteriorationFactor>0</extraDeteriorationFactor>
 		<edgeType>Hard</edgeType>
 		<traversedThought></traversedThought>
-		<extraNonDraftedPerceivedPathCost>0</extraNonDraftedPerceivedPathCost>
+		<extraNonDraftedPerceivedPathCost>18</extraNonDraftedPerceivedPathCost>
 		<extraDraftedPerceivedPathCost>18</extraDraftedPerceivedPathCost>
 		<pathCost>0</pathCost>
 		<layerable>true</layerable>


### PR DESCRIPTION
I built a pool in the middle of a plaza and my pawns keep pathing over it which slows them down much more than if they had walked around. When drafted they path around it correctly, so I tried setting `extraNonDraftedPerceivedPathCost` to the same as `extraDraftedPerceivedPathCost` and that seemed to fix it.

This value has been present in every version of the mod. I'm unsure if it was intentional or not, but it feels like a bug.

I'm also not sure what the actual `pathCost` property means, I couldn't really find documentation on the Defs. My guess is that probably that should just get set to 18 in the two extra path cost properties to 0, but I'm not looking at the code so that's just speculation.